### PR TITLE
force dhcp server to append static route for metadata

### DIFF
--- a/etc/t6/puppet_template/centos_compute.pp
+++ b/etc/t6/puppet_template/centos_compute.pp
@@ -256,6 +256,15 @@ if %(deploy_dhcp_agent)s {
         setting           => 'dhcp_driver',
         value             => 'bsnstacklib.plugins.bigswitch.dhcp_driver.DnsmasqWithMetaData',
     }
+    ini_setting { "force to use dhcp for metadata":
+        ensure            => present,
+        path              => '/etc/neutron/dhcp_agent.ini',
+        section           => 'DEFAULT',
+        key_val_separator => '=',
+        setting           => 'force_metadata',
+        value             => 'True',
+        notify            => Service['neutron-dhcp-agent'],
+    }
     ini_setting { "dhcp agent enable isolated metadata":
         ensure            => present,
         path              => '/etc/neutron/dhcp_agent.ini',

--- a/etc/t6/puppet_template/ubuntu_compute.pp
+++ b/etc/t6/puppet_template/ubuntu_compute.pp
@@ -248,6 +248,15 @@ if %(deploy_dhcp_agent)s {
         value             => 'bsnstacklib.plugins.bigswitch.dhcp_driver.DnsmasqWithMetaData',
         notify            => Service['neutron-dhcp-agent'],
     }
+    ini_setting { "force to use dhcp for metadata":
+        ensure            => present,
+        path              => '/etc/neutron/dhcp_agent.ini',
+        section           => 'DEFAULT',
+        key_val_separator => '=',
+        setting           => 'force_metadata',
+        value             => 'True',
+        notify            => Service['neutron-dhcp-agent'],
+    }
     ini_setting { "dhcp agent enable isolated metadata":
         ensure            => present,
         path              => '/etc/neutron/dhcp_agent.ini',


### PR DESCRIPTION
Reviewer: @kjiang 
This field is new in liberty. We need to add it to fuel plugin for t6