### PR TITLE
minor fix related to bsn_service_plugin

### DIFF
--- a/etc/t5/bash_template/centos_7.sh
+++ b/etc/t5/bash_template/centos_7.sh
@@ -32,6 +32,10 @@ controller() {
     # deploy bcf
     puppet apply --modulepath /etc/puppet/modules %(dst_dir)s/%(hostname)s.pp
 
+    # bsnstacklib installed and property files updated. now perform live db migration
+    echo "Performing live DB migration for Neutron.."
+    neutron-db-manage upgrade heads
+
     # deploy bcf horizon patch to controller node
     cp /usr/lib/python2.7/site-packages/horizon_bsn/enabled/* /usr/share/openstack-dashboard/openstack_dashboard/enabled/
     systemctl restart httpd

--- a/etc/t5/bash_template/redhat_7.sh
+++ b/etc/t5/bash_template/redhat_7.sh
@@ -44,6 +44,10 @@ controller() {
     # deploy bcf
     sudo puppet apply --modulepath /etc/puppet/modules %(dst_dir)s/%(hostname)s.pp
 
+    # bsnstacklib installed and property files updated. now perform live db migration
+    echo "Performing live DB migration for Neutron.."
+    neutron-db-manage upgrade heads
+
     # restart keystone and httpd
     sudo systemctl daemon-reload
     sudo systemctl restart openstack-keystone

--- a/etc/t5/bash_template/ubuntu_14.sh
+++ b/etc/t5/bash_template/ubuntu_14.sh
@@ -17,6 +17,10 @@ controller() {
     # deploy bcf
     puppet apply --modulepath /etc/puppet/modules %(dst_dir)s/%(hostname)s.pp
 
+    # bsnstacklib installed and property files updated. now perform live db migration
+    echo "Performing live DB migration for Neutron.."
+    neutron-db-manage upgrade heads
+
     echo 'Stop and disable neutron-metadata-agent, neutron-dhcp-agent and neutron-l3-agent'
     if [[ ${fuel_cluster_id} != 'None' ]]; then
         crm resource stop p_neutron-dhcp-agent
@@ -37,7 +41,7 @@ controller() {
     mv /etc/init/neutron-dhcp-agent.conf /etc/init/neutron-dhcp-agent.conf.disabled
     service neutron-l3-agent stop
     mv /etc/init/neutron-l3-agent.conf /etc/init/neutron-l3-agent.conf.disabled
-    
+
 
     # deploy horizon plugin
     cp /usr/local/lib/python2.7/dist-packages/horizon_bsn/enabled/* /usr/share/openstack-dashboard/openstack_dashboard/enabled/
@@ -120,7 +124,7 @@ set +e
 
 # Make sure only root can run this script
 if [[ "$(id -u)" != "0" ]]; then
-   echo -e "Please run as root" 
+   echo -e "Please run as root"
    exit 1
 fi
 

--- a/etc/t5/puppet_template/centos_controller.pp
+++ b/etc/t5/puppet_template/centos_controller.pp
@@ -202,7 +202,7 @@ ini_setting { "neutron.conf service_plugins":
   section           => 'DEFAULT',
   key_val_separator => '=',
   setting           => 'service_plugins',
-  value             => 'router',
+  value             => 'router,bsn_service_plugin',
   notify            => Service['neutron-server'],
 }
 ini_setting { "neutron.conf dhcp_agents_per_network":

--- a/etc/t5/puppet_template/redhat_controller.pp
+++ b/etc/t5/puppet_template/redhat_controller.pp
@@ -76,7 +76,7 @@ ini_setting { "neutron.conf service_plugins":
   section           => 'DEFAULT',
   key_val_separator => '=',
   setting           => 'service_plugins',
-  value             => 'router',
+  value             => 'router,bsn_service_plugin',
   notify            => Service['neutron-server'],
 }
 ini_setting { "neutron.conf dhcp_agents_per_network":
@@ -178,7 +178,7 @@ ini_setting { "l3 agent disable metadata proxy":
   value             => 'True',
 }
 
-# config /etc/neutron/plugins/ml2/ml2_conf.ini 
+# config /etc/neutron/plugins/ml2/ml2_conf.ini
 ini_setting { "ml2 type dirvers":
   ensure            => present,
   path              => '/etc/neutron/plugins/ml2/ml2_conf.ini',

--- a/etc/t5/puppet_template/ubuntu_controller.pp
+++ b/etc/t5/puppet_template/ubuntu_controller.pp
@@ -136,7 +136,7 @@ ini_setting { "neutron.conf service_plugins":
   section           => 'DEFAULT',
   key_val_separator => '=',
   setting           => 'service_plugins',
-  value             => 'router',
+  value             => 'router,bsn_service_plugin',
   notify            => Service['neutron-server'],
 }
 ini_setting { "neutron.conf dhcp_agents_per_network":
@@ -220,7 +220,7 @@ ini_setting { "l3 agent external network bridge":
   value             => '',
 }
 
-# config /etc/neutron/plugins/ml2/ml2_conf.ini 
+# config /etc/neutron/plugins/ml2/ml2_conf.ini
 ini_setting { "ml2 type dirvers":
   ensure            => present,
   path              => '/etc/neutron/plugins/ml2/ml2_conf.ini',

--- a/etc/t6/bash_template/centos_7.sh
+++ b/etc/t6/bash_template/centos_7.sh
@@ -32,6 +32,10 @@ controller() {
     # deploy bcf
     puppet apply --modulepath /etc/puppet/modules %(dst_dir)s/%(hostname)s.pp
 
+    # bsnstacklib installed and property files updated. now perform live db migration
+    echo "Performing live DB migration for Neutron.."
+    neutron-db-manage upgrade heads
+
     # deploy bcf horizon patch to controller node
     cp /usr/lib/python2.7/site-packages/horizon_bsn/enabled/* /usr/share/openstack-dashboard/openstack_dashboard/enabled/
     systemctl restart httpd
@@ -185,7 +189,7 @@ set +e
 
 # Make sure only root can run this script
 if [ "$(id -u)" != "0" ]; then
-   echo -e "Please run as root" 
+   echo -e "Please run as root"
    exit 1
 fi
 

--- a/etc/t6/bash_template/ubuntu_14.sh
+++ b/etc/t6/bash_template/ubuntu_14.sh
@@ -23,6 +23,10 @@ controller() {
     # deploy bcf
     puppet apply --modulepath /etc/puppet/modules %(dst_dir)s/%(hostname)s.pp
 
+    # bsnstacklib installed and property files updated. now perform live db migration
+    echo "Performing live DB migration for Neutron.."
+    neutron-db-manage upgrade heads
+
     echo 'Stop and disable neutron-metadata-agent and neutron-dhcp-agent'
     if [[ ${fuel_cluster_id} != 'None' ]]; then
         crm resource stop p_neutron-dhcp-agent
@@ -45,7 +49,7 @@ controller() {
     rm -f /etc/init/neutron-l3-agent.conf
     service neutron-bsn-agent stop
     rm -f /etc/init/neutron-bsn-agent.conf
-    
+
 
     # deploy horizon plugin
     cp /usr/local/lib/python2.7/dist-packages/horizon_bsn/enabled/* /usr/share/openstack-dashboard/openstack_dashboard/enabled/
@@ -243,7 +247,7 @@ set +e
 
 # Make sure only root can run this script
 if [[ "$(id -u)" != "0" ]]; then
-   echo -e "Please run as root" 
+   echo -e "Please run as root"
    exit 1
 fi
 

--- a/etc/t6/puppet_template/centos_controller.pp
+++ b/etc/t6/puppet_template/centos_controller.pp
@@ -223,7 +223,7 @@ ini_setting { "neutron.conf service_plugins":
   section           => 'DEFAULT',
   key_val_separator => '=',
   setting           => 'service_plugins',
-  value             => 'bsn_l3',
+  value             => 'bsn_l3,bsn_service_plugin',
   notify            => Service['neutron-server'],
 }
 ini_setting { "neutron.conf dhcp_agents_per_network":
@@ -293,7 +293,7 @@ ini_setting { "l3 agent disable metadata proxy":
   value             => 'False',
 }
 
-# config /etc/neutron/plugins/ml2/ml2_conf.ini 
+# config /etc/neutron/plugins/ml2/ml2_conf.ini
 ini_setting { "ml2 type dirvers":
   ensure            => present,
   path              => '/etc/neutron/plugins/ml2/ml2_conf.ini',
@@ -481,7 +481,7 @@ ini_setting { "clear tunnel type":
   section           => 'ovs',
   key_val_separator => '=',
   setting           => 'tunnel_type',
-  require           => File['/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini'],  
+  require           => File['/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini'],
   notify            => Service['neutron-openvswitch-agent'],
 }
 ini_setting { "clear tunnel types":

--- a/etc/t6/puppet_template/ubuntu_controller.pp
+++ b/etc/t6/puppet_template/ubuntu_controller.pp
@@ -163,7 +163,7 @@ ini_setting { "neutron.conf service_plugins":
   section           => 'DEFAULT',
   key_val_separator => '=',
   setting           => 'service_plugins',
-  value             => 'bsn_l3',
+  value             => 'bsn_l3,bsn_service_plugin',
   notify            => Service['neutron-server'],
 }
 ini_setting { "neutron.conf dhcp_agents_per_network":
@@ -243,7 +243,7 @@ ini_setting { "l3 agent disable metadata proxy":
   value             => 'False',
 }
 
-# config /etc/neutron/plugins/ml2/ml2_conf.ini 
+# config /etc/neutron/plugins/ml2/ml2_conf.ini
 ini_setting { "ml2 type dirvers":
   ensure            => present,
   path              => '/etc/neutron/plugins/ml2/ml2_conf.ini',


### PR DESCRIPTION
Reviewer: @xinwu 

 - updated neutron.conf to have bsn_service_plugin listed
 - execute 'neutron-db-manage upgrade heads' after bsnstacklib is installed and neutron.conf is updated
 - neutron-db-manage upgrade heads is idempotent. executing it multiple times is ok