### PR TITLE
skip membership rule programming

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1233,10 +1233,10 @@ class Helper(object):
         elif env.fuel_cluster_id:
             node_dic, membership_rules = Helper.load_nodes_from_fuel(
                 node_yaml_config_map, env)
-            for br_key, rule in membership_rules.iteritems():
-                RestLib.program_segment_and_membership_rule(
-                    env.bcf_master, env.bcf_cookie, rule,
-                    env.bcf_openstack_management_tenant)
+            #for br_key, rule in membership_rules.iteritems():
+            #    RestLib.program_segment_and_membership_rule(
+            #        env.bcf_master, env.bcf_cookie, rule,
+            #        env.bcf_openstack_management_tenant)
             return node_dic
         elif env.rhosp:
             # TODO: no longer supported after BCF 3.5. We moved to


### PR DESCRIPTION
This is due to port-group -> interface-group change, kilo and liberty support mis-match

Reviewer: trivial