### PR TITLE
horizon-bsn now has tags for release version, update bosi for the same

### DIFF
--- a/etc/t5/bash_template/centos_7.sh
+++ b/etc/t5/bash_template/centos_7.sh
@@ -187,10 +187,10 @@ if [[ $install_bsnstacklib == true ]]; then
     sleep 2
     if [[ $pip_proxy == false ]]; then
         pip install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip install --upgrade horizon-bsn
+        pip install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     else
         pip --proxy $pip_proxy  install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip --proxy $pip_proxy  install --upgrade horizon-bsn
+        pip --proxy $pip_proxy  install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     fi
 fi
 

--- a/etc/t5/bash_template/ubuntu_14.sh
+++ b/etc/t5/bash_template/ubuntu_14.sh
@@ -163,10 +163,10 @@ if [[ $install_bsnstacklib == true ]]; then
     sleep 2
     if [[ $pip_proxy == false ]]; then
         pip install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip install --upgrade horizon-bsn
+        pip install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     else
         pip --proxy $pip_proxy  install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip --proxy $pip_proxy  install --upgrade horizon-bsn
+        pip --proxy $pip_proxy  install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     fi
 fi
 

--- a/etc/t6/bash_template/centos_7.sh
+++ b/etc/t6/bash_template/centos_7.sh
@@ -221,10 +221,10 @@ if [[ $install_bsnstacklib == true ]]; then
     sleep 2
     if [[ $pip_proxy == false ]]; then
         pip install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip install --upgrade horizon-bsn
+        pip install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     else
         pip --proxy $pip_proxy  install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip --proxy $pip_proxy  install --upgrade horizon-bsn
+        pip --proxy $pip_proxy  install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     fi
 fi
 

--- a/etc/t6/bash_template/ubuntu_14.sh
+++ b/etc/t6/bash_template/ubuntu_14.sh
@@ -286,10 +286,10 @@ if [[ $install_bsnstacklib == true ]]; then
     sleep 2
     if [[ $pip_proxy == false ]]; then
         pip install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip install --upgrade horizon-bsn
+        pip install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     else
         pip --proxy $pip_proxy  install --upgrade "bsnstacklib>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
-        pip --proxy $pip_proxy  install --upgrade horizon-bsn
+        pip --proxy $pip_proxy  install --upgrade "horizon-bsn>%(bsnstacklib_version_lower)s,<%(bsnstacklib_version_upper)s"
     fi
 fi
 


### PR DESCRIPTION
Reviewer: @xinwu 

 - since the numbering convention is same as `bsnstacklib`, we re-use the same version number variables
 - redhat t5 is not modified since it doesn't include the horizon-bsn plugin at all