### PR TITLE
BVS-5926 use regex to get and install epel-release package

### DIFF
--- a/etc/t5/bash_template/centos_7.sh
+++ b/etc/t5/bash_template/centos_7.sh
@@ -167,7 +167,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # prepare dependencies
-rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+wget -r --no-parent --no-directories --timestamping --accept 'epel-release-7-*.rpm' 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/'
+rpm -iUvh epel-release-7-*.rpm
 rpm -ivh https://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-10.noarch.rpm
 yum groupinstall -y 'Development Tools'
 yum install -y python-devel puppet python-pip wget libffi-devel openssl-devel

--- a/etc/t5/bash_template/redhat_7.sh
+++ b/etc/t5/bash_template/redhat_7.sh
@@ -145,7 +145,8 @@ if [[ $? == 0 ]]; then
 fi
 
 # prepare dependencies
-sudo rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+wget -r --no-parent --no-directories --timestamping --accept 'epel-release-7-*.rpm' 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/'
+rpm -iUvh epel-release-7-*.rpm
 sudo rpm -ivh https://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-10.noarch.rpm
 sudo yum update -y
 sudo yum groupinstall -y 'Development Tools'

--- a/etc/t6/bash_template/centos_7.sh
+++ b/etc/t6/bash_template/centos_7.sh
@@ -201,7 +201,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # prepare dependencies
-rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+wget -r --no-parent --no-directories --timestamping --accept 'epel-release-7-*.rpm' 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/'
+rpm -iUvh epel-release-7-*.rpm
 rpm -ivh https://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-10.noarch.rpm
 yum groupinstall -y 'Development Tools'
 yum install -y python-devel puppet python-pip wget libffi-devel openssl-devel


### PR DESCRIPTION
Reviewer: @xinwu 

 - upstream fedora changes epel-release number and doesn't
   retain old file
 - use regex to wget and install