### PR TITLE
BVS-6545 remove verbose option from ivs daemon args

### DIFF
--- a/bosi/lib/constants.py
+++ b/bosi/lib/constants.py
@@ -60,7 +60,7 @@ LOG_FILE = "/var/log/bcf_setup.log"
 
 # constants for ivs config
 INBAND_VLAN = 4092
-IVS_DAEMON_ARGS_CERT = (r'''DAEMON_ARGS=\"--hitless --verbose --certificate /etc/ivs '''
+IVS_DAEMON_ARGS_CERT = (r'''DAEMON_ARGS=\"--hitless --certificate /etc/ivs '''
                         '''--inband-vlan %(inband_vlan)d'''
                         '''%(uplink_interfaces)s%(internal_ports)s\\"''')
 IVS_DAEMON_ARGS = (r'''DAEMON_ARGS=\"--hitless '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.163
+version = 0.0.167
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @xinwu 
CC: @brajneesh 

 - i'll cherry pick this to bcf-3.6 branch of bosi too