### PR TITLE
BVS-6648: nfvswitch: add customize and starup scripts for rhel packaging

### DIFF
--- a/bosi/nfvswitch/README
+++ b/bosi/nfvswitch/README
@@ -1,0 +1,27 @@
+This directory contains the rpm packages of Big Switch
+openstack plugins, switch light virtual rpm and a few
+helper scripts. RHOSP and BCF have different release
+schedules. As a result, the Big Switch openstack plugins
+in RHOSP overcloud image may not always be compatable
+with a particular BCF release. The rpm packages in this
+directory is verified to work with BCF 4.0 and RHOSP9.0.
+Please refer to BCF deployment guide for the steps to
+patch RHOSP overcloud images.
+
+python-networking-bigswitch-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+contains the Big Switch ml2 plugin and l3 service plugin
+
+openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+contains the Big Switch lldp service
+
+openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+contains the Big Switch virtual switch agent
+
+python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
+contains the Big Switch horizon plugin
+
+nfvswitch-${nfvswitch_version}-1.el7.centos.x86_64.rpm
+contains the Big Switch switch light virtual
+
+startup.sh
+is the script needs to be run on undercloud node first boot

--- a/bosi/nfvswitch/README
+++ b/bosi/nfvswitch/README
@@ -23,5 +23,10 @@ contains the Big Switch horizon plugin
 nfvswitch-${nfvswitch_version}-1.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual
 
+qemu-system-x86-2.5.0-4bsn1.el7.centos.x86_64.rpm
+qemu-common-2.5.0-4bsn1.el7.centos.x86_64.rpm
+qemu-img-2.5.0-4bsn1.el7.centos.x86_64.rpm
+contains the qemu version needed by nfvswitch
+
 startup.sh
 is the script needs to be run on undercloud node first boot

--- a/bosi/nfvswitch/customize.sh
+++ b/bosi/nfvswitch/customize.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export LIBGUESTFS_BACKEND=direct
+
+image_dir="/home/stack/images"
+
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload python-networking-bigswitch-${bsnstacklib_version}-1.el7.centos.noarch.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload nfvswitch-${nfvswitch_version}-1.el7.centos.x86_64.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload nfvswitch-debuginfo-${nfvswitch_version}-1.el7.centos.x86_64.rpm:/root/
+
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --firstboot startup.sh
+

--- a/bosi/nfvswitch/startup.sh
+++ b/bosi/nfvswitch/startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+yum remove -y openstack-neutron-bigswitch-agent
+yum remove -y openstack-neutron-bigswitch-lldp
+yum remove -y python-networking-bigswitch
+rpm -ivh --force /root/python-networking-bigswitch-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+rpm -ivh --force /root/openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+rpm -ivh --force /root/openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm
+rpm -ivh --force /root/python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
+rpm -ivh --force /root/nfvswitch-${nfvswitch_version}-1.el7.centos.x86_64.rpm
+rpm -ivh --force /root/nfvswitch-debuginfo-${nfvswitch_version}-1.el7.centos.x86_64.rpm
+systemctl enable neutron-bsn-lldp.service
+systemctl restart neutron-bsn-lldp.service

--- a/bosi/nfvswitch/startup.sh
+++ b/bosi/nfvswitch/startup.sh
@@ -3,11 +3,15 @@
 yum remove -y openstack-neutron-bigswitch-agent
 yum remove -y openstack-neutron-bigswitch-lldp
 yum remove -y python-networking-bigswitch
+
 rpm -ivh --force /root/python-networking-bigswitch-${bsnstacklib_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/nfvswitch-${nfvswitch_version}-1.el7.centos.x86_64.rpm
-rpm -ivh --force /root/nfvswitch-debuginfo-${nfvswitch_version}-1.el7.centos.x86_64.rpm
+rpm -ivh --force /root/qemu-system-x86-2.5.0-4bsn1.el7.centos.x86_64.rpm
+rpm -ivh --force /root/qemu-common-2.5.0-4bsn1.el7.centos.x86_64.rpm
+rpm -ivh --force /root/qemu-img-2.5.0-4bsn1.el7.centos.x86_64.rpm
+
 systemctl enable neutron-bsn-lldp.service
 systemctl restart neutron-bsn-lldp.service


### PR DESCRIPTION
Reviewer: @wolverineav 

The plan is to have a separate Jenkins Job for nfvswitch BVS-6835 which fetches necessary rpms and uses this new folder to generate the tarball.

Please verify this change doesn't break/interfere with our other builds/tarballs for Bosi/Fuel/Rhel-IVS