### PR TITLE
make openstack bcf compatibility matrix cleaner

### DIFF
--- a/bosi/lib/constants.py
+++ b/bosi/lib/constants.py
@@ -21,22 +21,38 @@ T5 = 't5'
 MODE_DICT = {'pfabric': T5,
              'pvfabric': T6}
 
-OS_RELEASE_TO_BSN_LIB = {'kilo': '20151',
-                         'liberty': '20153',
-                         'mitaka': '8'}
+OS_BCF_MAPPING_LOWER = {
+    'kilo': {
+        '3.6': '20151.36'
+    },
+    'liberty': {
+        '3.6': '20153.36',
+        '3.7': '20153.36',
+        '4.0': '20153.36'
+    },
+    'mitaka': {
+        '3.7': '8.37',
+        '4.0': '8.37'
+    }
+}
 
-# prev release constant to better map lower bsnstacklib version.
-# these are branch specific aka release specific.
-OS_RELEASE_PREV = 'liberty'
-BCF_RELEASE_PREV = '3.6'
-
-#BCF release
-BCF_RELEASE_TO_BSN_LIB_LOWER = {'3.6': '36.0',
-                                '3.7': '37.0',
-                                '4.0': '40.0'}
-BCF_RELEASE_TO_BSN_LIB_UPPER = {'3.6': '37.0',
-                                '3.7': '38.0',
-                                '4.0': '41.0'}
+OS_BCF_MAPPING_UPPER = {
+    'kilo': {
+        '3.6': '20151.37'
+    },
+    'liberty': {
+        '3.6': '20153.37',
+        '3.7': '20153.38',
+        '4.0': '20153.41'
+    },
+    'mitaka': {
+        # NOTE : we released a 8.40 by mistake and cannot downgrade on pypi,
+        # hence upper is 8.41 instead of 8.38. we'll have to keep track
+        # of incompatibilities to make sure it doesn't break anything
+        '3.7': '8.41',
+        '4.0': '8.41'
+    }
+}
 
 # Since kilo and BCF 3.5, we use tenant name
 # instead of tenant uuid to configure tenants,

--- a/bosi/lib/environment.py
+++ b/bosi/lib/environment.py
@@ -153,24 +153,15 @@ class Environment(object):
 
         # openstack bsnstacklib version - applies to horizon plugin too
         self.openstack_release = str(config['openstack_release']).lower()
-        prefix = const.OS_RELEASE_TO_BSN_LIB.get(self.openstack_release)
         array = self.bcf_version.split('.')
         if len(array) == 3:
             array = array[:-1]
-        version = '.'.join(array)
+        two_digit_bcfversion = '.'.join(array)
 
-        # special handling for 'prev' release of openstack i.e. one lower than
-        # the current one. we may not bump the version since it supports
-        # prev release of BCF
-        if self.openstack_release == const.OS_RELEASE_PREV:
-            bcf_lower = const.BCF_RELEASE_TO_BSN_LIB_LOWER[
-                const.BCF_RELEASE_PREV]
-        else:
-            bcf_lower = const.BCF_RELEASE_TO_BSN_LIB_LOWER[version]
-
-        self.bsnstacklib_version_lower = (prefix + '.' + bcf_lower)
-        self.bsnstacklib_version_upper = (prefix + '.' +
-            const.BCF_RELEASE_TO_BSN_LIB_UPPER[version])
+        self.bsnstacklib_version_lower = const.OS_BCF_MAPPING_LOWER[
+            self.openstack_release][two_digit_bcfversion]
+        self.bsnstacklib_version_upper = const.OS_BCF_MAPPING_UPPER[
+            self.openstack_release][two_digit_bcfversion]
 
         # master bcf controller and cookie
         self.bcf_master = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.180
+version = 0.0.181
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - one step closer to having a single bosi branch
 - the previous way of individually picking openstack and bcf version doesn't work well
 - liberty support was added in 3.6, picking 3.6 from 4.0 seems weird. instead having a map this way make it clear to figure out.

acking it since trivial change and will be required before 4.0 beta