### PR TITLE
BVS-7020: correct verify logic for ivs 4.0.0~beta1

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1637,10 +1637,12 @@ class Helper(object):
         # required version is node.ivs_version
         output = Helper.run_command_on_remote(node, r'''ivs --version''')
         # version string looks like this:
-        # ivs 3.0.0 (2015-08-14.18:26-39a875b trusty-amd64)
+        # ivs 3.0.0 (2015-08-14.18:26-39a875b trusty-amd64) or
+        # ivs 4.0.0-beta1 (2016-09-30.05:05-0a88b15 centos7-x86_64)
         split_version = string.split(output, ' ')
         # split_version[1] would be empty in error scenario
-        if node.ivs_version == split_version[1]:
+        if (split_version[1] and
+                (node.ivs_version == string.split(split_version[1], '-')[0])):
             return ':-)'
         else:
             return (':-( Expected ' + node.ivs_version +

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.181
+version = 0.0.182
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: trivial
CC: @sarath-kumar 

 - with the IVS change in, the version string according to `rpm` spec is `4.0.0`
 - so we need to skip the `-beta1` found in `ivs --version`