### PR TITLE
BVS-7020: correct verify logic for ivs 4.0.0~beta1

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1637,16 +1637,15 @@ class Helper(object):
         # required version is node.ivs_version
         output = Helper.run_command_on_remote(node, r'''ivs --version''')
         # version string looks like this:
-        # ivs 3.0.0 (2015-08-14.18:26-39a875b trusty-amd64)
+        # ivs 3.0.0 (2015-08-14.18:26-39a875b trusty-amd64) or
+        # ivs 4.0.0-beta1 (2016-09-30.05:05-0a88b15 centos7-x86_64)
         split_version = string.split(output, ' ')
-        # for ivs 4.0.0-beta1, the spec file contains 4.0.0~beta1
-        #  i.e. tilde ~ instead of hyphen -
-        expected_ivs_version = string.replace(node.ivs_version, '~', '-')
         # split_version[1] would be empty in error scenario
-        if expected_ivs_version == split_version[1]:
+        if (split_version[1] and
+                (node.ivs_version == string.split(split_version[1], '-')[0])):
             return ':-)'
         else:
-            return (':-( Expected ' + expected_ivs_version +
+            return (':-( Expected ' + node.ivs_version +
                     ' Actual ' + split_version[1])
 
     @staticmethod

--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1639,11 +1639,14 @@ class Helper(object):
         # version string looks like this:
         # ivs 3.0.0 (2015-08-14.18:26-39a875b trusty-amd64)
         split_version = string.split(output, ' ')
+        # for ivs 4.0.0-beta1, the spec file contains 4.0.0~beta1
+        #  i.e. tilde ~ instead of hyphen -
+        expected_ivs_version = string.replace(node.ivs_version, '~', '-')
         # split_version[1] would be empty in error scenario
-        if node.ivs_version == split_version[1]:
+        if expected_ivs_version == split_version[1]:
             return ':-)'
         else:
-            return (':-( Expected ' + node.ivs_version +
+            return (':-( Expected ' + expected_ivs_version +
                     ' Actual ' + split_version[1])
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 4.0.1
+version = 4.0.2
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: trivial
CC: @sarath-kumar 

 - with the IVS change in, the version string according to `rpm` spec is `4.0.0`
 - so we need to skip the `-beta1` found in `ivs --version`