### PR TITLE
bring 3.7 up to date with changes in master [cherry-pick]

### DIFF
--- a/bosi/bosi.py
+++ b/bosi/bosi.py
@@ -398,6 +398,9 @@ def main():
                         help=("Fuel cluster ID. Fuel settings may override "
                               "YAML configuration. "
                               "Please refer to config.yaml"))
+    parser.add_argument('-r', "--rhosp", action='store_true', default=False,
+                        help="red hat openstack director is the installer "
+                             "(upgrade only supported).")
     parser.add_argument('-t', "--tag", required=False,
                         help="Deploy to tagged nodes only.")
     parser.add_argument('--cleanup', action='store_true', default=False,
@@ -432,15 +435,19 @@ def main():
 
 
     args = parser.parse_args()
+    if args.fuel_cluster_id and args.rhosp:
+        safe_print("Cannot have both fuel and rhosp as openstack installer.\n")
+        return
+    if args.rhosp and not args.upgrade_dir:
+        safe_print("BOSI for RHOSP only supports upgrading packages.\n"
+                   "Please specify --upgrade-dir.\n")
     if args.certificate_only and (not args.certificate_dir):
         safe_print("--certificate-only requires the existence of --certificate-dir.\n")
         return
 
     with open(args.config_file, 'r') as config_file:
         config = yaml.load(config_file)
-    # bosi is not used for redhat any more since 3.6
-    rhosp = False
-    deploy_bcf(config, args.deploy_mode, args.fuel_cluster_id, rhosp,
+    deploy_bcf(config, args.deploy_mode, args.fuel_cluster_id, args.rhosp,
                args.tag, args.cleanup,
                args.verify, args.verifyonly,
                args.skip_ivs_version_check,

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -103,9 +103,19 @@ echo "nfvswitch version is" $NFVSWITCH_VERSION
 echo "bsnstacklib version is" $BSNSTACKLIB_VERSION
 echo "horizon-bsn version is" $HORIZON_BSN_VERSION
 
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/customize.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/startup.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/README
+# IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
+# that needs to be adhered.
+IVS_VERSION_REVISION = "$IVS_VERSION""-1"
+# for beta releases, revision is preappended, no changes required
+# i.e. 4.0.0-beta1 already has revision set to beta1
+if [[ "$IVS_VERSION" == *"beta"* ]]
+then
+    IVS_VERSION_REVISION = "$IVS_VERSION"
+fi
+
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/customize.sh
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/startup.sh
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/README
 
 DATE=`date +%Y-%m-%d`
 TAR_NAME="BCF-RHOSP-$RHOSPVersion-plugins-$NFVSWITCH_VERSION.$Revision-$DATE"

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -67,9 +67,23 @@ get_version () {
     V=${B##*-};
 }
 
-NFVSWITCH_PKG="`ls ./tarball/nfvswitch-debug*`"
-get_version $NFVSWITCH_PKG
-NFVSWITCH_VERSION=$V
+# given $BcfBranch is master, IVS_VERSION will be whatever value set in master.
+# hence we take it from package name
+IVS_VERSION="$IvsBranch"
+if [ "$IVS_VERSION" == "master" ]
+then
+    IVS_PKG="`ls ./tarball/ivs-debug*`"
+    get_version $IVS_PKG
+    IVS_VERSION=$V
+fi
+
+NFVSWITCH_VERSION="$IvsBranch"
+if [ "$NFVSWITCH_VERSION" == "master" ]
+then
+    NFVSWITCH_PKG="`ls ./tarball/nfvswitch-debug*`"
+    get_version $NFVSWITCH_PKG
+    NFVSWITCH_VERSION=$V
+fi
 
 # bsnstacklib and horizon-bsn is <openstack-version>.<bcf-version>.<bug-fix-id>
 # however, to maintain compatibility with lower version of bcf releases,

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -85,8 +85,7 @@ echo "bsnstacklib version is" $BSNSTACKLIB_VERSION
 echo "horizon-bsn version is" $HORIZON_BSN_VERSION
 
 sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/customize.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/startup_compute.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/startup_controller.sh
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/startup.sh
 sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" ./tarball/README
 
 DATE=`date +%Y-%m-%d`

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -105,12 +105,12 @@ echo "horizon-bsn version is" $HORIZON_BSN_VERSION
 
 # IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
 # that needs to be adhered.
-IVS_VERSION_REVISION = "$IVS_VERSION""-1"
+IVS_VERSION_REVISION="$IVS_VERSION""-1"
 # for beta releases, revision is preappended, no changes required
 # i.e. 4.0.0-beta1 already has revision set to beta1
 if [[ "$IVS_VERSION" == *"beta"* ]]
 then
-    IVS_VERSION_REVISION = "$IVS_VERSION"
+    IVS_VERSION_REVISION="$IVS_VERSION"
 fi
 
 sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${nfvswitch_version}/$NFVSWITCH_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/customize.sh

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -19,7 +19,6 @@ esac
 
 # if IvsBranch is not specified, it is same as BcfBranch
 if [ -z "${IvsBranch+x}" ]; then
-then
     IvsBranch="$BcfBranch"
 fi
 

--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -17,6 +17,12 @@ case "$OpenStackBranch" in
   *"kilo"*) RHOSPVersion="7" ;;
 esac
 
+# if IvsBranch is not specified, it is same as BcfBranch
+if [ -z "${IvsBranch+x}" ]; then
+then
+    IvsBranch="$BcfBranch"
+fi
+
 # cleanup old stuff
 sudo rm -rf *
 

--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -89,12 +89,12 @@ echo "horizon-bsn version is" $HORIZON_BSN_VERSION
 
 # IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
 # that needs to be adhered.
-IVS_VERSION_REVISION = "$IVS_VERSION""-1"
+IVS_VERSION_REVISION="$IVS_VERSION""-1"
 # for beta releases, revision is preappended, no changes required
 # i.e. 4.0.0-beta1 already has revision set to beta1
 if [[ "$IVS_VERSION" == *"beta"* ]]
 then
-    IVS_VERSION_REVISION = "$IVS_VERSION"
+    IVS_VERSION_REVISION="$IVS_VERSION"
 fi
 
 sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/customize.sh

--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -19,7 +19,7 @@ case "$OpenStackBranch" in
 esac
 
 # if IvsBranch is not specified, it is same as BcfBranch
-if [ -z  $IvsBranch  ]
+if [ -z "${IvsBranch+x}" ]; then
 then
     IvsBranch="$BcfBranch"
 fi

--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -20,7 +20,6 @@ esac
 
 # if IvsBranch is not specified, it is same as BcfBranch
 if [ -z "${IvsBranch+x}" ]; then
-then
     IvsBranch="$BcfBranch"
 fi
 

--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -87,9 +87,19 @@ echo "ivs version is" $IVS_VERSION
 echo "bsnstacklib version is" $BSNSTACKLIB_VERSION
 echo "horizon-bsn version is" $HORIZON_BSN_VERSION
 
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION/" ./tarball/customize.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION/" ./tarball/startup.sh
-sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION/" ./tarball/README
+# IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
+# that needs to be adhered.
+IVS_VERSION_REVISION = "$IVS_VERSION""-1"
+# for beta releases, revision is preappended, no changes required
+# i.e. 4.0.0-beta1 already has revision set to beta1
+if [[ "$IVS_VERSION" == *"beta"* ]]
+then
+    IVS_VERSION_REVISION = "$IVS_VERSION"
+fi
+
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/customize.sh
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/startup.sh
+sed -i -e "s/\${bsnstacklib_version}/$BSNSTACKLIB_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./tarball/README
 
 DATE=`date +%Y-%m-%d`
 TAR_NAME="BCF-RHOSP-$RHOSPVersion-plugins-$IVS_VERSION.$Revision-$DATE"

--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -62,9 +62,13 @@ get_version () {
 
 # given $BcfBranch is master, IVS_VERSION will be whatever value set in master.
 # hence we take it from package name
-IVS_PKG="`ls ./tarball/ivs-debug*`"
-get_version $IVS_PKG
-IVS_VERSION=$V
+IVS_VERSION="$IvsBranch"
+if [ "$IVS_VERSION" == "master" ]
+then
+    IVS_PKG="`ls ./tarball/ivs-debug*`"
+    get_version $IVS_PKG
+    IVS_VERSION=$V
+fi
 
 # bsnstacklib and horizon-bsn is <openstack-version>.<bcf-version>.<bug-fix-id>
 # however, to maintain compatibility with lower version of bcf releases,

--- a/bosi/rhosp_resources/ivs/README
+++ b/bosi/rhosp_resources/ivs/README
@@ -20,10 +20,10 @@ contains the Big Switch virtual switch agent
 python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
 contains the Big Switch horizon plugin
 
-ivs-${ivs_version}-1.el7.centos.x86_64.rpm
+ivs-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual
 
-ivs-debuginfo-${ivs_version}-1.el7.centos.x86_64.rpm
+ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual debugging tools
 
 ifup-ivs

--- a/bosi/rhosp_resources/ivs/customize.sh
+++ b/bosi/rhosp_resources/ivs/customize.sh
@@ -8,8 +8,8 @@ virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload python-networking-b
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm:/root/
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm:/root/
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm:/root/
-virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-${ivs_version}-1.el7.centos.x86_64.rpm:/root/
-virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-debuginfo-${ivs_version}-1.el7.centos.x86_64.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-${ivs_version}.el7.centos.x86_64.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm:/root/
 
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ifup-ivs:/etc/sysconfig/network-scripts/ifup-ivs
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --run-command 'chmod a+x /etc/sysconfig/network-scripts/ifup-ivs'

--- a/bosi/rhosp_resources/ivs/startup.sh
+++ b/bosi/rhosp_resources/ivs/startup.sh
@@ -7,7 +7,7 @@ rpm -ivh --force /root/python-networking-bigswitch-${bsnstacklib_version}-1.el7.
 rpm -ivh --force /root/openstack-neutron-bigswitch-agent-${bsnstacklib_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/openstack-neutron-bigswitch-lldp-${bsnstacklib_version}-1.el7.centos.noarch.rpm
 rpm -ivh --force /root/python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
-rpm -ivh --force /root/ivs-${ivs_version}-1.el7.centos.x86_64.rpm
-rpm -ivh --force /root/ivs-debuginfo-${ivs_version}-1.el7.centos.x86_64.rpm
+rpm -ivh --force /root/ivs-${ivs_version}.el7.centos.x86_64.rpm
+rpm -ivh --force /root/ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
 systemctl enable neutron-bsn-lldp.service
 systemctl restart neutron-bsn-lldp.service

--- a/etc/bosi_config/config.yaml
+++ b/etc/bosi_config/config.yaml
@@ -30,11 +30,11 @@ bcf_controller_passwd: adminadmin
 # mandatory for fuel deployment, the tenant name for fuel networks
 bcf_openstack_management_tenant: os-mgmt
 
-# mandatory if the openstack installer takes over pxe boot (fuel)
+# mandatory if the openstack installer takes over pxe boot (fuel, rhosp)
 # It will be the default gw for all nodes if external gw is not specified.
 installer_pxe_interface_ip: 192.168.1.1
 
-# mandatory if the openstack installer can list all nodes (fuel).
+# mandatory if the openstack installer can list all nodes (fuel, rhosp).
 # bosi directly gets node list from openstack installer
 # and deploys bcf patch to all of them by default.
 # If user wants to deploy bcf patch only on specified
@@ -44,6 +44,13 @@ deploy_to_specified_nodes_only: false
 # mandatory, used to let bcf ml2 plugin differenciate different openstack clusters
 neutron_id: neutron
 
+# mandatory for rhosp, red hat registration information
+rhosp_automate_register: true
+rhosp_installer_management_interface: eno2
+rhosp_installer_pxe_interface: eno1
+rhosp_undercloud_dns: 8.8.8.8
+rhosp_register_username: bigswitch
+rhosp_register_passwd: bigswitch
 
 # All following configurations can be overrided by openstack installers
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 3.7.3
+version = 3.7.4
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - getting latest build related changes to 3.7
 - side note: i can remove `rhosp_nfvswitch_packager.sh` since we don't have nfvswitch in 3.7?