### PR TITLE
update script for liberty_ksv3 branch

### DIFF
--- a/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_packager.sh
@@ -34,9 +34,14 @@ rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/xenon-bsn/
 mkdir bsnstacklib
 rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/bsnstacklib/centos7-x86_64/$OpenStackBranch/latest/* ./bsnstacklib
 
+# since we have special branching for bsnstacklib, we need to sanitize it for horizon-bsn package
+HorizonBsnBranch="$OpenStackBranch"
+if [[ "$OpenStackBranch" == *"liberty_ksv3"* ]]; then
+    HorizonBsnBranch="origin/stable/liberty"
+fi
 # get horizon-bsn packages
 mkdir horizon-bsn
-rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/horizon-bsn/centos7-x86_64/$OpenStackBranch/latest/* ./horizon-bsn
+rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/horizon-bsn/centos7-x86_64/$HorizonBsnBranch/latest/* ./horizon-bsn
 
 # get bosi packages
 mkdir bosi


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - the only thing affected with the branch path is `horizon-bsn`, since it should still point to `origin/stable/liberty` even in special case
 - everything else remains same