### PR TITLE
update bosi to pick nfvswitch package after update

### DIFF
--- a/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
+++ b/bosi/rhosp_resources/build_scripts/rhosp_nfvswitch_packager.sh
@@ -33,7 +33,7 @@ rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/xenon-bsn/
 
 # get nfvswitch packages
 mkdir nfvswitch
-rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/nfvswitch/centos7-x86_64/latest/* ./nfvswitch
+rsync -e 'ssh -o "StrictHostKeyChecking no"' -uva  bigtop:public_html/nfvswitch/centos7-x86_64/$IvsBranch/latest/* ./nfvswitch
 
 # get bsnstacklib packages
 mkdir bsnstacklib


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - this goes in sync with https://github.com/bigswitch/nfvswitch/pull/272
 - assuming `NfvSwitchBranch` is same as `IvsBranch`. if that is not the case, we need to introduce a new variable for specifying `NfvSwitchBranch`