### PR TITLE
OSP-32: cleanup old versions when upgrading packages

### DIFF
--- a/etc/t5/bash_template/redhat_7_upgrade.sh
+++ b/etc/t5/bash_template/redhat_7_upgrade.sh
@@ -9,7 +9,7 @@ controller() {
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
             yum remove -y python-networking-bigswitch
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             neutron-db-manage upgrade heads
             systemctl enable neutron-server
@@ -22,7 +22,7 @@ controller() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
             yum remove -y openstack-neutron-bigswitch-lldp
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable  neutron-bsn-lldp
             systemctl restart neutron-bsn-lldp
@@ -34,7 +34,7 @@ controller() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
             yum remove -y openstack-neutron-bigswitch-agent
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl stop neutron-bsn-agent
             systemctl disable neutron-bsn-agent
             break
@@ -45,7 +45,7 @@ controller() {
     do
         if [[ $pkg == *"python-horizon-bsn"* ]]; then
             yum remove -y python-horizon-bsn
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl restart httpd
             break
         fi
@@ -60,7 +60,7 @@ compute() {
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
             yum remove -y python-networking-bigswitch
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             break
         fi
     done
@@ -69,7 +69,7 @@ compute() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
             yum remove -y openstack-neutron-bigswitch-agent
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl stop neutron-bsn-agent
             systemctl disable neutron-bsn-agent
@@ -81,7 +81,7 @@ compute() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
             yum remove -y openstack-neutron-bigswitch-lldp
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable neutron-bsn-lldp
             systemctl restart neutron-bsn-lldp

--- a/etc/t6/bash_template/centos_7.sh
+++ b/etc/t6/bash_template/centos_7.sh
@@ -73,14 +73,14 @@ compute() {
         fi
 
         if [[ $pass == true ]]; then
-            rpm -ivh --force %(dst_dir)s/%(ivs_pkg)s
+            rpm -ivhU --force %(dst_dir)s/%(ivs_pkg)s
             if [[ -f %(dst_dir)s/%(ivs_debug_pkg)s ]]; then
-                rpm -ivh --force %(dst_dir)s/%(ivs_debug_pkg)s
+                rpm -ivhU --force %(dst_dir)s/%(ivs_debug_pkg)s
             fi
         elif [[ $skip_ivs_version_check == true ]]; then
-            rpm -ivh --force %(dst_dir)s/%(ivs_pkg)s
+            rpm -ivhU --force %(dst_dir)s/%(ivs_pkg)s
             if [[ -f %(dst_dir)s/%(ivs_debug_pkg)s ]]; then
-                rpm -ivh --force %(dst_dir)s/%(ivs_debug_pkg)s
+                rpm -ivhU --force %(dst_dir)s/%(ivs_debug_pkg)s
             fi
         else
             echo "ivs upgrade fails version validation"

--- a/etc/t6/bash_template/centos_7_upgrade.sh
+++ b/etc/t6/bash_template/centos_7_upgrade.sh
@@ -41,7 +41,7 @@ compute() {
             systemctl restart neutron-bsn-agent
         fi
         if [[ $pkg == *"ivs"* ]]; then
-            rpm -ivh --force $pkg
+            rpm -ivhU --force $pkg
             systemctl enable  ivs
             systemctl restart ivs
         fi

--- a/etc/t6/bash_template/redhat_7_upgrade.sh
+++ b/etc/t6/bash_template/redhat_7_upgrade.sh
@@ -9,7 +9,7 @@ controller() {
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
             yum remove -y python-networking-bigswitch
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             neutron-db-manage upgrade heads
             systemctl enable neutron-server
@@ -22,7 +22,7 @@ controller() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
             yum remove -y openstack-neutron-bigswitch-lldp
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable  neutron-bsn-lldp
             systemctl restart neutron-bsn-lldp
@@ -34,7 +34,7 @@ controller() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
             yum remove -y openstack-neutron-bigswitch-agent
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl stop neutron-bsn-agent
             systemctl disable neutron-bsn-agent
@@ -46,7 +46,7 @@ controller() {
     do
         if [[ $pkg == *"python-horizon-bsn"* ]]; then
             yum remove -y python-horizon-bsn
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl restart httpd
             break
         fi
@@ -61,7 +61,7 @@ compute() {
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
             yum remove -y python-networking-bigswitch
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             break
         fi
     done
@@ -70,7 +70,7 @@ compute() {
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
             yum remove -y openstack-neutron-bigswitch-agent
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable neutron-bsn-agent
             systemctl restart neutron-bsn-agent
@@ -81,7 +81,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"ivs-debuginfo"* ]]; then
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             break
         fi
     done
@@ -95,7 +95,7 @@ compute() {
             if [[ $pkg == *"-ivs"* ]]; then
                 continue
             fi
-            rpm -ivh $pkg --force
+            rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable ivs
             systemctl restart ivs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.184
+version = 0.0.185
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - it was missing a `-U` option to specify upgrade. thus creating a separate package installation