### PR TITLE
OSP-55: fixes for sriov changes

### DIFF
--- a/bosi/bosi.py
+++ b/bosi/bosi.py
@@ -42,7 +42,7 @@ def worker_upgrade_or_sriov_node(q):
                    {'fqdn': node.fqdn})
 
         start_time = datetime.datetime.now()
-        if node.role is const.ROLE_SRIOV:
+        if node.role == const.ROLE_SRIOV:
             Helper.run_command_on_remote(node,
                 (r'''sudo bash %(dst_dir)s/%(hostname)s_sriov.sh''' %
                 {'dst_dir': node.dst_dir,
@@ -231,14 +231,17 @@ def setup_sriov(node_dic):
             safe_print("skip node %(fqdn)s due to mismatched tag\n" %
                       {'fqdn': node.fqdn})
             continue
-        if node.role is not const.ROLE_SRIOV:
+        if node.role != const.ROLE_SRIOV:
             safe_print("Skipping node %(hostname)s because deployment mode is "
-                       "SRIOV and role set for node is not SRIOV." %
-                       {'hostname': hostname})
-        if node.os is not const.REDHAT:
+                       "SRIOV and role set for node is not SRIOV. It is "
+                       "%(role)s\n" %
+                       {'hostname': hostname, 'role': node.role})
+            continue
+        if node.os != const.REDHAT:
             safe_print("Skipping node %(hostname)s because deployment mode is "
-                       "SRIOV and non REDHAT OS is not supported." %
-                       {'hostname': hostname})
+                       "SRIOV and non REDHAT OS is not supported. OS set for "
+                       "node is %(os)s\n" %
+                       {'hostname': hostname, 'os': node.os})
             continue
 
         # all okay, generate scripts for node
@@ -275,7 +278,7 @@ def deploy_bcf(config, mode, fuel_cluster_id, rhosp, tag, cleanup,
     safe_print("Start to prepare setup node\n")
     env = Environment(config, mode, fuel_cluster_id, rhosp, tag, cleanup,
                       skip_ivs_version_check, certificate_dir, upgrade_dir,
-                      offline_dir)
+                      offline_dir, sriov)
     Helper.common_setup_node_preparation(env)
     controller_nodes = []
 

--- a/bosi/lib/environment.py
+++ b/bosi/lib/environment.py
@@ -11,7 +11,7 @@ from rest import RestLib
 class Environment(object):
     def __init__(self, config, mode, fuel_cluster_id, rhosp, tag,
                  cleanup, skip_ivs_version_check, certificate_dir,
-                 upgrade_dir, offline_dir):
+                 upgrade_dir, offline_dir, sriov):
         # directory for upgrade
         self.upgrade_dir = None
         self.upgrade_pkgs = []
@@ -25,6 +25,9 @@ class Environment(object):
         if offline_dir:
             self.offline_dir = offline_dir
             self.offline_pkgs = [f for f in listdir(offline_dir) if isfile(join(offline_dir, f))]
+
+        # sriov for rhosp
+        self.sriov = sriov
 
         # certificate directory
         self.certificate_dir = certificate_dir

--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -371,7 +371,7 @@ class Helper(object):
     def generate_sriov_scripts(node, bash_template):
         with open((r'''%(setup_node_dir)s/%(deploy_mode)s/'''
                    '''%(bash_template_dir)s/%(bash_template)s_'''
-                   '''%(os_version)s_%(role)s.sh''' %
+                   '''%(os_version)s_sriov.sh''' %
                    {'setup_node_dir': node.setup_node_dir,
                     'deploy_mode': node.deploy_mode,
                     'bash_template_dir': const.BASH_TEMPLATE_DIR,
@@ -382,15 +382,14 @@ class Helper(object):
             bash_template_content = bash_template_file.read()
 
             active_active = False if len(node.sriov_physnets) == 2 else True
-            bash = (
-                bash_template_content %
-                {'fqdn': node.fqdn,
-                 'active_active': str(active_active).lower(),
-                 'phy1_name': node.get_sriov_phy1_name(),
-                 'phy1_nics': node.get_sriov_phy1_nics(),
-                 'phy2_name': node.get_sriov_phy2_name(),
-                 'phy2_nics': node.get_sriov_phy2_nics()
-                 })
+            bash = bash_template_content.format(**{
+                'fqdn': node.fqdn,
+                'phy1_name': node.get_sriov_phy1_name(),
+                'phy1_nics': node.get_sriov_phy1_nics(),
+                'phy2_name': node.get_sriov_phy2_name(),
+                'phy2_nics': node.get_sriov_phy2_nics(),
+                'active_active': str(active_active).lower(),
+            })
         bash_script_path = (
             r'''%(setup_node_dir)s/%(generated_script_dir)s'''
             '''/%(hostname)s_sriov.sh''' %
@@ -888,7 +887,7 @@ class Helper(object):
         node_config['hostname'] = hostname
         # In case of RHOSP, SRIOV nodes need to be explicitly specified
         node_config['role'] = (const.ROLE_SRIOV
-                               if node_config['role'] is const.ROLE_SRIOV
+                               if node_config['role'] == const.ROLE_SRIOV
                                else role)
         node = Node(node_config, env)
         if node.skip:
@@ -1374,7 +1373,7 @@ class Helper(object):
                            'generated_script': const.GENERATED_SCRIPT_DIR},
                         shell=True)
 
-        if env.upgrade_dir:
+        if env.upgrade_dir or env.sriov:
             # don't need other preparation for upgrade
             return
 
@@ -1680,7 +1679,7 @@ class Helper(object):
                      dst_dir, pkg)
             return
 
-        if node.role is const.ROLE_SRIOV:
+        if node.role == const.ROLE_SRIOV:
             # copy bash script to node
             safe_print("Copy bash script to %(hostname)s\n" %
                       {'hostname': node.fqdn})

--- a/bosi/lib/node.py
+++ b/bosi/lib/node.py
@@ -111,7 +111,7 @@ class Node(object):
         self.sriov_physnets = {}
 
         # setup SRIOV physnets
-        if self.role is const.ROLE_SRIOV:
+        if self.role == const.ROLE_SRIOV:
             if not 'physnets' in node_config:
                 self.skip = True
                 self.error = (r'''physnets not specified for SRIOV node'''

--- a/etc/bosi_config/config.yaml
+++ b/etc/bosi_config/config.yaml
@@ -44,14 +44,6 @@ deploy_to_specified_nodes_only: false
 # mandatory, used to let bcf ml2 plugin differenciate different openstack clusters
 neutron_id: neutron
 
-# mandatory for rhosp, red hat registration information
-rhosp_automate_register: true
-rhosp_installer_management_interface: eno2
-rhosp_installer_pxe_interface: eno1
-rhosp_undercloud_dns: 8.8.8.8
-rhosp_register_username: bigswitch
-rhosp_register_passwd: bigswitch
-
 # All following configurations can be overrided by openstack installers
 
 # node os user name

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.195
+version = 0.0.196
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
 - path for send_lldp varies for redhat node as compared to centos
 - args to the service are escaped with forward slashes, sed to make it back to hyphens