### PR TITLE
OSP-55: don't daemonize in service file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.196
+version = 0.0.197
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
 - daemonizing send_lldp results in error state
 - this is because service tries to check process state and
   cannot since the code spawned a daemon thread and died