### PR TITLE
upgrade nfvswitch during RHOSP upgrade

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1666,7 +1666,8 @@ class Helper(object):
             clear_dir_cmd = (r'''rm -rf %(dst_dir)s/*''' % {'dst_dir': dst_dir})
             Helper.run_command_on_remote_without_timeout(node, clear_dir_cmd)
             for pkg in node.upgrade_pkgs:
-                if (node.role != const.ROLE_COMPUTE) and ("ivs" in pkg):
+                if (node.role != const.ROLE_COMPUTE
+                    and ("ivs" in pkg or "nfvswitch" in pkg)):
                     safe_print("Skipping pkg {pkg} since node role is not "
                                "COMPUTE, it is {role}".format(
                         **{'pkg': pkg, 'role': node.role}))

--- a/etc/t6/bash_template/redhat_7_upgrade.sh
+++ b/etc/t6/bash_template/redhat_7_upgrade.sh
@@ -102,6 +102,29 @@ compute() {
             break
         fi
     done
+
+    # do the same as IVS for NFVSWITCH
+    for pkg in $PKGS
+    do
+        if [[ $pkg == *"nfvswitch-debuginfo"* ]]; then
+            rpm -ivhU $pkg --force
+            break
+        fi
+    done
+
+    for pkg in $PKGS
+    do
+        if [[ $pkg == *"nfvswitch"* ]]; then
+            if [[ $pkg == *"nfvswitch-debuginfo"* ]]; then
+                continue
+            fi
+            rpm -ivhU $pkg --force
+            systemctl daemon-reload
+            systemctl enable nfvswitch
+            systemctl restart nfvswitch
+            break
+        fi
+    done
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.200
+version = 0.0.201
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: trivial
CC: @sarath-kumar @padubidry 

 - this only applies to RHOSP for now, since NFVSWITCH is not
   supported on any other platform