### PR TITLE
OSP-64: add support for no-bonding along with active-active

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -384,8 +384,10 @@ class Helper(object):
             active_active = False if len(node.sriov_physnets) == 2 else True
             bash = bash_template_content.format(**{
                 'fqdn': node.fqdn,
-                'phy1_name': node.get_sriov_phy_name(),
-                'phy1_nics': node.get_sriov_phy_nics(),
+                'phy1_name': node.get_sriov_phy1_name(),
+                'phy1_nics': node.get_sriov_phy1_nics(),
+                'phy2_name': node.get_sriov_phy2_name(),
+                'phy2_nics': node.get_sriov_phy2_nics(),
                 'active_active': str(active_active).lower(),
                 'system_desc': node.sriov_bond_mode.value,
             })

--- a/bosi/lib/node.py
+++ b/bosi/lib/node.py
@@ -119,22 +119,21 @@ class Node(object):
                 self.skip = True
                 self.error = (r'''physnets not specified for SRIOV node'''
                               '''%(hostname)s''' % {'hostname': self.hostname})
-            if 'physnets' in node_config and len(node_config['physnets']) > 1:
+            if 'physnets' in node_config and len(node_config['physnets']) > 2:
                 self.skip = True
-                self.error = (r'''Cannot have more than one physnet for '''
-                              '''SRIOV node %(hostname)s. Supported mode is '''
-                              '''active-active.''' %
+                self.error = (r'''Cannot have more than two physents for '''
+                              '''SRIOV node %(hostname)s''' %
                               {'hostname': self.hostname})
             if not self.skip:
                 for phy in node_config['physnets']:
                     if ('phy_name' not in phy
                         or 'uplink_interfaces' not in phy
-                        or len(phy['uplink_interfaces']) != 2):
+                        or len(phy['uplink_interfaces']) > 2):
                         self.skip = True
                         self.error = (r'''Either missing phy_name or '''
-                                      '''uplink_interfaces or number of '''
-                                      '''uplink_interface is not equal to 2 '''
-                                      '''for SRIOV node %(hostname)s''' %
+                                      '''uplink_interfaces or more than 2 '''
+                                      '''uplink_interfaces found for SRIOV '''
+                                      '''node %(hostname)s''' %
                                       {'hostname': self.hostname})
                         break
                     self.sriov_physnets[phy['phy_name']] = \
@@ -366,15 +365,25 @@ class Node(object):
     def get_bsnstacklib_version_upper(self):
         return self.bsnstacklib_version_upper
 
-    def get_sriov_phy_name(self):
+    def get_sriov_phy1_name(self):
         if len(self.sriov_physnets) < 1:
             return ''
         return self.sriov_physnets.items()[0][0]
 
-    def get_sriov_phy_nics(self):
+    def get_sriov_phy1_nics(self):
         if len(self.sriov_physnets) < 1:
             return ''
         return ','.join(self.sriov_physnets.items()[0][1])
+
+    def get_sriov_phy2_name(self):
+        if len(self.sriov_physnets) < 2:
+            return ''
+        return self.sriov_physnets.items()[1][0]
+
+    def get_sriov_phy2_nics(self):
+        if len(self.sriov_physnets) < 2:
+            return ''
+        return ','.join(self.sriov_physnets.items()[1][1])
 
     def __str__(self):
         return (

--- a/etc/bosi_config/config.yaml
+++ b/etc/bosi_config/config.yaml
@@ -87,6 +87,8 @@ nodes:
   - phy_name: physnetA
     uplink_interfaces:
     - p1p1
+  - phy_name: physnetB
+    uplink_interfaces:
+    - p1p2
     bond_mode: lacp
-
 - hostname: 10.4.9.103

--- a/etc/t6/bash_template/redhat_7_sriov.sh
+++ b/etc/t6/bash_template/redhat_7_sriov.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -eux
 # env variables to be supplied by BOSI
 fqdn={fqdn}
 phy1_name={phy1_name}
@@ -9,7 +9,6 @@ active_active={active_active}
 system_desc={system_desc}
 
 # constants for this job
-LOG_FILE="/var/log/bcf_setup.log"
 SERVICE_FILE_1='/usr/lib/systemd/system/send_lldp_1.service'
 SERVICE_FILE_2='/usr/lib/systemd/system/send_lldp_2.service'
 SERVICE_FILE_MULTI_USER_1='/etc/systemd/system/multi-user.target.wants/send_lldp_1.service'
@@ -20,7 +19,7 @@ HOSTNAME=`cat /etc/hostname`
 
 # Make sure only root can run this script
 if [ "$(id -u)" != "0" ]; then
-   echo -e "Please run as root" >> $LOG_FILE
+   echo -e "Please run as root"
    exit 1
 fi
 
@@ -87,4 +86,4 @@ if [[ $active_active != true ]]; then
     systemctl start send_lldp_2
 fi
 
-echo "Finished updating with SRIOV LLDP scripts."   >> $LOG_FILE
+echo "Finished updating with SRIOV LLDP scripts."

--- a/etc/t6/bash_template/redhat_7_sriov.sh
+++ b/etc/t6/bash_template/redhat_7_sriov.sh
@@ -3,13 +3,16 @@
 fqdn={fqdn}
 phy1_name={phy1_name}
 phy1_nics={phy1_nics}
+phy2_name={phy2_name}
+phy2_nics={phy2_nics}
 active_active={active_active}
-system_desc={system_desc}
 
 # constants for this job
 LOG_FILE="/var/log/bcf_setup.log"
 SERVICE_FILE_1='/usr/lib/systemd/system/send_lldp_1.service'
+SERVICE_FILE_2='/usr/lib/systemd/system/send_lldp_2.service'
 SERVICE_FILE_MULTI_USER_1='/etc/systemd/system/multi-user.target.wants/send_lldp_1.service'
+SERVICE_FILE_MULTI_USER_2='/etc/systemd/system/multi-user.target.wants/send_lldp_2.service'
 
 # new vars with evaluated results
 HOSTNAME=`cat /etc/hostname`
@@ -20,8 +23,11 @@ if [ "$(id -u)" != "0" ]; then
    exit 1
 fi
 
-# if service file exists, stop the service. else, return true
+# if service file exists, stop and disable the service. else, return true
 systemctl stop send_lldp_1 | true
+systemctl stop send_lldp_2 | true
+systemctl disable send_lldp_1 | true
+systemctl disable send_lldp_2 | true
 
 # rewrite service file
 echo "
@@ -43,10 +49,41 @@ WantedBy=multi-user.target
 # symlink multi user file
 ln -sf $SERVICE_FILE_1 $SERVICE_FILE_MULTI_USER_1
 
+if [[ $active_active == true ]]; then
+    rm $SERVICE_FILE_2
+    rm $SERVICE_FILE_MULTI_USER_2
+else
+echo "
+[Unit]
+Description=BSN send_lldp for physnet 2
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/python /usr/lib/python2.7/site-packages/networking_bigswitch/bsnlldp/send_lldp.py --system-desc ${{system_desc}} --system-name ${{HOSTNAME}}-${{phy2_name}} -i 10 --network_interface ${{phy2_nics}}
+Restart=always
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+" > $SERVICE_FILE_2
+
+# add multi user symlink for send_lldp_2
+ln -sf $SERVICE_FILE_2 $SERVICE_FILE_MULTI_USER_2
+fi
+
 # reload service files
 systemctl daemon-reload
 
 # start services as required
-systemctl restart send_lldp_1
+systemctl enable send_lldp_1
+systemctl start send_lldp_1
+
+if [[ $active_active != true ]]; then
+    # no bonding, start both agents
+    systemctl start send_lldp_1
+    systemctl start send_lldp_2
+fi
 
 echo "Finished updating with SRIOV LLDP scripts."   >> $LOG_FILE

--- a/etc/t6/bash_template/redhat_7_sriov.sh
+++ b/etc/t6/bash_template/redhat_7_sriov.sh
@@ -6,6 +6,7 @@ phy1_nics={phy1_nics}
 phy2_name={phy2_name}
 phy2_nics={phy2_nics}
 active_active={active_active}
+system_desc={system_desc}
 
 # constants for this job
 LOG_FILE="/var/log/bcf_setup.log"

--- a/etc/t6/bash_template/redhat_7_sriov.sh
+++ b/etc/t6/bash_template/redhat_7_sriov.sh
@@ -82,7 +82,7 @@ systemctl start send_lldp_1
 
 if [[ $active_active != true ]]; then
     # no bonding, start both agents
-    systemctl start send_lldp_1
+    systemctl enable send_lldp_2
     systemctl start send_lldp_2
 fi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.202
+version = 0.0.203
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar 
CC: @padubidry 

 - i had removed the part for multiple physnets since we were supporting active-active only
 - but that is required for `no-bonding` mode, so adding it back