### PR TITLE
OSP-46: ensure bosi compatibility with newton+

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1549,16 +1549,27 @@ class Helper(object):
             # put all controllers to rabbit hosts
             neutron_conf = open(
                 "%s/neutron.conf" % controller_node.setup_node_dir, 'r')
-            for line in neutron_conf:
-                if line.startswith("rabbit_hosts"):
-                    hosts_str = line.split("=")[1].strip()
-                    hosts = hosts_str.split(',')
-                    for host in hosts:
-                        if "127.0" in host:
-                            rabbit_port = host.split(':')[1]
-                            continue
-                        rabbit_hosts.add(host.strip())
-                    break
+            if len(controller_nodes) == 1:
+                for line in neutron_conf:
+                    if line.startswith("rabbit_host"):
+                        host_str = line.split("=")[1].strip()
+                        rabbit_hosts.add(host_str)
+                        continue
+                    elif line.startswith("rabbit_port"):
+                        rabbit_port = line.split("=")[1].strip()
+                        continue
+            else:
+                for line in neutron_conf:
+                    if line.startswith("rabbit_hosts"):
+                        hosts_str = line.split("=")[1].strip()
+                        hosts = hosts_str.split(',')
+                        for host in hosts:
+                            if "127.0" in host:
+                                rabbit_port = host.split(':')[1]
+                                continue
+                            rabbit_hosts.add(host.strip())
+                        break
+
 
         if len(controller_nodes):
             controller_node = controller_nodes[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 4.0.15
+version = 4.0.16
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
CC: @khayamgondal-bsn 

 - one of the properties for rabbit_hosts changed in neutron.conf
   for single host and multi host deployments