### PR TITLE
don't crap out at parsing error, continue

### DIFF
--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -1226,8 +1226,9 @@ class Helper(object):
                 hostname = str(
                     netaddr.IPAddress(columns[6].strip().split('=')[1]))
             except IndexError:
-                raise Exception("Could not parse node list:\n%(node_list)s\n"
-                                % {'node_list': node_list})
+                safe_print("Skipping the node due to parsing error. Node "
+                           "listing was: %(line)s\n" % {'line': line})
+                continue
 
             if online.lower() != 'active':
                 # skip offline nodes


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - trivial change - log message and continue in case of parsing error
 - the following would crash bosi otherwise:
```
| 964b4c95-f0b0-4f35-a60f-90ea2908c9df | overcloud-compute-130  | ACTIVE | -          | Running     | ctlplane=192.0.2.139 |
| cedf1491-97df-4b9f-8952-000ee4c9b664 | overcloud-compute-131  | ERROR  | -          | NOSTATE     |                      |
| fac895eb-fc5f-4bf9-ab87-93921b4964e0 | overcloud-compute-131  | ERROR  | -          | NOSTATE     |                      |
| 93e16b23-7550-4556-b7da-1d20c8bd1c0f | overcloud-compute-132  | ACTIVE | -          | Running     | ctlplane=192.0.2.152 |
```
the two error nodes without info in the last column.