### PR TITLE
OSP-184: bosi changes to deploy LLDP script for OVS DPDK

### DIFF
--- a/bosi/lib/constants.py
+++ b/bosi/lib/constants.py
@@ -32,6 +32,7 @@ ROLE_CEPH = 'ceph-osd'
 ROLE_CINDER = "cinder"
 ROLE_MONGO = 'mongo'
 ROLE_SRIOV = 'sriov'
+ROLE_DPDK = 'dpdk'
 
 # deployment t6/t5
 T6 = 't6'
@@ -211,10 +212,10 @@ class MetaEnum(EnumMeta):
         return item in cls.__members__
 
 
-class SriovBondMode(Enum):
+class BondMode(Enum):
     """
-    This maps sriov bond mode to its corresponding MAC address to be used by
-    the LLDP script as system-desc.
+    This maps SRIOV/DPDK bond mode to its corresponding MAC address to be
+    used by the LLDP script as system-desc.
     """
     __metaclass__ = MetaEnum
 

--- a/bosi/lib/environment.py
+++ b/bosi/lib/environment.py
@@ -26,7 +26,7 @@ from rest import RestLib
 class Environment(object):
     def __init__(self, config, mode, fuel_cluster_id, rhosp, tag,
                  cleanup, skip_ivs_version_check, certificate_dir,
-                 upgrade_dir, offline_dir, sriov):
+                 upgrade_dir, offline_dir, sriov, dpdk):
         # directory for upgrade
         self.upgrade_dir = None
         self.upgrade_pkgs = []
@@ -43,6 +43,9 @@ class Environment(object):
 
         # sriov for rhosp
         self.sriov = sriov
+
+        # dpdk for rhosp p-only
+        self.dpdk = dpdk
 
         # certificate directory
         self.certificate_dir = certificate_dir
@@ -116,7 +119,7 @@ class Environment(object):
             const.NETWORK_VLAN_RANGE_EXPRESSION, re.IGNORECASE)
         match = network_vlan_range_pattern.match(self.network_vlan_ranges)
         if not match:
-            Helper.safe_print("network_vlan_ranges' format is not correct.\n")
+            Helper.safe_print("network_vlan_ranges format is not correct.\n")
             exit(1)
         self.physnet = match.group(1)
         self.lower_vlan = match.group(2)
@@ -168,10 +171,10 @@ class Environment(object):
         self.role = config.get('default_role')
         self.user = config.get('default_user')
         # optional property, set default internally
-        self.sriov_bond_mode = const.SriovBondMode.STATIC
-        if config.get('default_sriov_bond_mode'):
-            self.sriov_bond_mode = const.SriovBondMode[
-                config.get('default_sriov_bond_mode').upper()]
+        self.bond_mode = const.BondMode.STATIC
+        if config.get('default_bond_mode'):
+            self.bond_mode = const.BondMode[
+                config.get('default_bond_mode').upper()]
         if rhosp:
             self.user = "heat-admin"
         elif fuel_cluster_id:

--- a/etc/bosi_config/config.yaml
+++ b/etc/bosi_config/config.yaml
@@ -73,7 +73,7 @@ default_uplink_interfaces:
 
 # optional, used in RHOSP SRIOV env.
 # legit options - static, lacp
-default_sriov_bond_mode: static
+default_bond_mode: static
 
 # list of nodes to be deployed
 nodes:
@@ -94,3 +94,10 @@ nodes:
     - p1p2
     bond_mode: lacp
 - hostname: 10.4.9.103
+  role: dpdk
+  physnets:
+  - phy_name: physnetdpdk
+    uplink_interfaces:
+    - p1p1
+    - p1p2
+- hostname: 10.4.9.104

--- a/etc/t5/bash_template/redhat_7_dpdk.sh
+++ b/etc/t5/bash_template/redhat_7_dpdk.sh
@@ -18,16 +18,11 @@
 fqdn={fqdn}
 phy1_name={phy1_name}
 phy1_nics={phy1_nics}
-phy2_name={phy2_name}
-phy2_nics={phy2_nics}
-active_active={active_active}
 system_desc={system_desc}
 
 # constants for this job
-SERVICE_FILE_1='/usr/lib/systemd/system/send_lldp_1.service'
-SERVICE_FILE_2='/usr/lib/systemd/system/send_lldp_2.service'
-SERVICE_FILE_MULTI_USER_1='/etc/systemd/system/multi-user.target.wants/send_lldp_1.service'
-SERVICE_FILE_MULTI_USER_2='/etc/systemd/system/multi-user.target.wants/send_lldp_2.service'
+SERVICE_FILE_1='/usr/lib/systemd/system/send_lldp.service'
+SERVICE_FILE_MULTI_USER_1='/etc/systemd/system/multi-user.target.wants/send_lldp.service'
 
 # new vars with evaluated results
 HOSTNAME=`cat /etc/hostname`
@@ -39,15 +34,13 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # if service file exists, stop and disable the service. else, return true
-systemctl stop send_lldp_1 | true
-systemctl stop send_lldp_2 | true
-systemctl disable send_lldp_1 | true
-systemctl disable send_lldp_2 | true
+systemctl stop send_lldp | true
+systemctl disable send_lldp | true
 
 # rewrite service file
 echo "
 [Unit]
-Description=BSN send_lldp for physnet 1
+Description=BSN send_lldp for DPDK physnet
 After=syslog.target network.target
 
 [Service]
@@ -69,46 +62,11 @@ WantedBy=multi-user.target
 # symlink multi user file
 ln -sf $SERVICE_FILE_1 $SERVICE_FILE_MULTI_USER_1
 
-if [[ $active_active == true ]]; then
-    rm $SERVICE_FILE_2
-    rm $SERVICE_FILE_MULTI_USER_2
-else
-echo "
-[Unit]
-Description=BSN send_lldp for physnet 2
-After=syslog.target network.target
-
-[Service]
-Type=simple
-ExecStart=/bin/python /usr/lib/python2.7/site-packages/networking_bigswitch/bsnlldp/send_lldp.py \
-    --system-desc ${{system_desc}} \
-    --system-name ${{HOSTNAME}}-${{phy2_name}} \
-    -i 10 \
-    --network_interface ${{phy2_nics}} \
-    --sriov
-Restart=always
-StartLimitInterval=60s
-StartLimitBurst=3
-
-[Install]
-WantedBy=multi-user.target
-" > $SERVICE_FILE_2
-
-# add multi user symlink for send_lldp_2
-ln -sf $SERVICE_FILE_2 $SERVICE_FILE_MULTI_USER_2
-fi
-
 # reload service files
 systemctl daemon-reload
 
 # start services as required
-systemctl enable send_lldp_1
-systemctl start send_lldp_1
+systemctl enable send_lldp
+systemctl start send_lldp
 
-if [[ $active_active != true ]]; then
-    # no bonding, start both agents
-    systemctl enable send_lldp_2
-    systemctl start send_lldp_2
-fi
-
-echo "Finished updating with SRIOV LLDP scripts."
+echo "Finished updating with DPDK LLDP scripts."


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - adds an option for dpdk, similar to sriov
 - specify role and physnets for dpdk nodes in `config.yaml`
 - specifying physnets is mandatory right now - but if we know there is only going to be one physnet, we can probably use the default physnet specification using `network_vlan_ranges` in `config.yaml`