### PR TITLE
OSP-184: systemname for OVS DPDK is dependent on role of node

### DIFF
--- a/bosi/bosi.py
+++ b/bosi/bosi.py
@@ -63,7 +63,7 @@ def worker_upgrade_or_sriov_node(q):
                 {'dst_dir': node.dst_dir,
                  'hostname': node.hostname,
                  'log': node.log}))
-        elif node.role == const.ROLE_DPDK:
+        elif node.role in const.DPDK_ROLES:
             Helper.run_command_on_remote(node,
                 (r'''sudo bash %(dst_dir)s/%(hostname)s_dpdk.sh''' %
                 {'dst_dir': node.dst_dir,
@@ -301,7 +301,7 @@ def setup_dpdk(node_dic):
             safe_print("skip node %(fqdn)s due to mismatched tag\n" %
                       {'fqdn': node.fqdn})
             continue
-        if node.role != const.ROLE_DPDK:
+        if node.role not in const.DPDK_ROLES:
             safe_print("Skipping node %(hostname)s because deployment mode is "
                        "DPDK and role set for node is not DPDK. It is "
                        "%(role)s\n" %

--- a/bosi/lib/constants.py
+++ b/bosi/lib/constants.py
@@ -32,7 +32,10 @@ ROLE_CEPH = 'ceph-osd'
 ROLE_CINDER = "cinder"
 ROLE_MONGO = 'mongo'
 ROLE_SRIOV = 'sriov'
-ROLE_DPDK = 'dpdk'
+ROLE_DPDK = 'ovs-dpdk'
+ROLE_DPDK_CONTROL = 'ovs-dpdk-controller'
+ROLE_DPDK_COMPUTE = 'ovs-dpdk-compute'
+DPDK_ROLES = [ROLE_DPDK, ROLE_DPDK_CONTROL, ROLE_DPDK_COMPUTE]
 
 # deployment t6/t5
 T6 = 't6'

--- a/bosi/lib/node.py
+++ b/bosi/lib/node.py
@@ -157,7 +157,7 @@ class Node(object):
                             phy['bond_mode'].upper()]
 
         # setup DPDK custom_physnets
-        if self.role == const.ROLE_DPDK:
+        if self.role in const.DPDK_ROLES:
             if (not 'physnets' in node_config
                 or len(node_config['physnets']) != 1):
                 self.skip = True

--- a/etc/bosi_config/config.yaml
+++ b/etc/bosi_config/config.yaml
@@ -94,7 +94,7 @@ nodes:
     - p1p2
     bond_mode: lacp
 - hostname: 10.4.9.103
-  role: dpdk
+  role: ovs-dpdk
   physnets:
   - phy_name: physnetdpdk
     uplink_interfaces:

--- a/etc/t5/bash_template/redhat_7_dpdk.sh
+++ b/etc/t5/bash_template/redhat_7_dpdk.sh
@@ -16,6 +16,7 @@
 
 # env variables to be supplied by BOSI
 fqdn={fqdn}
+is_controller={is_controller}
 phy1_name={phy1_name}
 phy1_nics={phy1_nics}
 system_desc={system_desc}
@@ -25,7 +26,13 @@ SERVICE_FILE_1='/usr/lib/systemd/system/send_lldp.service'
 SERVICE_FILE_MULTI_USER_1='/etc/systemd/system/multi-user.target.wants/send_lldp.service'
 
 # new vars with evaluated results
-HOSTNAME=`cat /etc/hostname`
+HOSTNAME=`hostname -f`
+
+# system name for LLDP depends on whether its a controller or compute node
+SYSTEMNAME=${{HOSTNAME}}-${{phy1_name}}
+if [[ $is_controller == true ]]; then
+    SYSTEMNAME=${{HOSTNAME}}
+fi
 
 # Make sure only root can run this script
 if [ "$(id -u)" != "0" ]; then
@@ -47,7 +54,7 @@ After=syslog.target network.target
 Type=simple
 ExecStart=/bin/python /usr/lib/python2.7/site-packages/networking_bigswitch/bsnlldp/send_lldp.py \
     --system-desc ${{system_desc}} \
-    --system-name ${{HOSTNAME}}-${{phy1_name}} \
+    --system-name ${{SYSTEMNAME}} \
     -i 10 \
     --network_interface ${{phy1_nics}} \
     --sriov


### PR DESCRIPTION
Reviewer: @sarath-kumar 

follow-up change to start lldp script on compute and controller with different hostnames.

 - compute node requires hostname-phyname as systemname
 - controller node needs just hostname
 - role is decided by taking `ovs-dpdk` from `config.yaml` and then using control/compute derived from `nova list` on undercloud
 - retrieving hostname using `cat /etc/hostname` doesn't include domain name. hence the change to `hostname -f`