### PR TITLE
OSP-184: change behaviour for dpdk [part 1][DO NOT MERGE]

### DIFF
--- a/bosi/lib/environment.py
+++ b/bosi/lib/environment.py
@@ -21,6 +21,7 @@ from os.path import isfile
 from os.path import join
 import re
 from rest import RestLib
+import yaml
 
 
 class Environment(object):
@@ -46,6 +47,15 @@ class Environment(object):
 
         # dpdk for rhosp p-only
         self.dpdk = dpdk
+        self.dpdk_phy_name = None
+        if self.dpdk:
+            # read network-environment.yaml and get dpdk_phy_name
+            net_env_file = (
+                open('/home/stack/templates/network-environment.yaml', 'r'))
+            net_env_config = yaml.load(net_env_file)
+            bridge_mappings = (
+                net_env_config['parameter_defaults']['NeutronBridgeMappings'])
+            self.dpdk_phy_name = bridge_mappings.split(':')[0]
 
         # certificate directory
         self.certificate_dir = certificate_dir

--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -433,7 +433,7 @@ class Helper(object):
 
             bash = bash_template_content.format(**{
                 'is_controller': str(is_controller).lower(),
-                'phy1_name': node.get_custom_phy1_name(),
+                'dpdk_phy_name': node.dpdk_phy_name,
                 'system_desc': node.bond_mode.value,
             })
         bash_script_path = (

--- a/bosi/lib/helper.py
+++ b/bosi/lib/helper.py
@@ -432,10 +432,8 @@ class Helper(object):
                 is_controller = True
 
             bash = bash_template_content.format(**{
-                'fqdn': node.fqdn,
                 'is_controller': str(is_controller).lower(),
                 'phy1_name': node.get_custom_phy1_name(),
-                'phy1_nics': node.get_custom_phy1_nics(),
                 'system_desc': node.bond_mode.value,
             })
         bash_script_path = (
@@ -933,19 +931,17 @@ class Helper(object):
         else:
             return None
         node_config['hostname'] = hostname
-        # In case of RHOSP, SRIOV & DPDK nodes need to be explicitly specified
-        if node_config['role']:
-            if node_config['role'] == const.ROLE_DPDK:
-                # For DPDK nodes, consider their original roles and assign a
-                # specific DPDK subrole based on that.
-                if role == const.ROLE_COMPUTE:
-                    node_config['role'] = const.ROLE_DPDK_COMPUTE
-                elif role == const.ROLE_NEUTRON_SERVER:
-                    node_config['role'] = const.ROLE_DPDK_CONTROL
-            elif node_config['role'] == const.ROLE_SRIOV:
-                node_config['role'] = const.ROLE_SRIOV
-            else:
-                node_config['role'] = role
+        # In case of RHOSP, SRIOV nodes need to be explicitly specified
+        node_config['role'] = (const.ROLE_SRIOV
+                               if node_config['role'] == const.ROLE_SRIOV
+                               else role)
+        # In case of RHOSP, DPDK deployments, env variable 'dpdk' dictates role
+        if env.dpdk:
+            node_config['role'] = const.ROLE_DPDK
+            if role == const.ROLE_COMPUTE:
+                node_config['role'] = const.ROLE_DPDK_COMPUTE
+            if role == const.ROLE_NEUTRON_SERVER:
+                node_config['role'] = const.ROLE_DPDK_CONTROL
 
         node = Node(node_config, env)
         if node.skip:

--- a/bosi/lib/node.py
+++ b/bosi/lib/node.py
@@ -125,6 +125,7 @@ class Node(object):
         self.old_ivs_version = node_config.get('old_ivs_version')
         self.bond_mode = env.bond_mode
         self.custom_physnets = {}
+        self.dpdk_phy_name = env.dpdk_phy_name
 
         # setup SRIOV custom_physnets
         if self.role == const.ROLE_SRIOV:
@@ -155,32 +156,6 @@ class Node(object):
                     if 'bond_mode' in phy:
                         self.bond_mode = const.BondMode[
                             phy['bond_mode'].upper()]
-
-        # setup DPDK custom_physnets
-        # if self.role in const.DPDK_ROLES:
-        #     if (not 'physnets' in node_config
-        #         or len(node_config['physnets']) != 1):
-        #         self.skip = True
-        #         self.error = (r'''physnets not specified or more than one '''
-        #                       '''specified for DPDK node %(hostname)s'''
-        #                       % {'hostname': self.hostname})
-        #     if not self.skip:
-        #         for phy in node_config['physnets']:
-        #             if ('phy_name' not in phy
-        #                 or 'uplink_interfaces' not in phy
-        #                 or len(phy['uplink_interfaces']) > 2):
-        #                 self.skip = True
-        #                 self.error = (r'''Either missing phy_name or '''
-        #                               '''uplink_interfaces or more than 2 '''
-        #                               '''uplink_interfaces found for SRIOV '''
-        #                               '''node %(hostname)s''' %
-        #                               {'hostname': self.hostname})
-        #                 break
-        #             self.custom_physnets[phy['phy_name']] = \
-        #                 phy['uplink_interfaces']
-        #             if 'bond_mode' in phy:
-        #                 self.bond_mode = const.BondMode[
-        #                     phy['bond_mode'].upper()]
 
         # in case of config env (packstack), bond and br_bond
         # may be empty
@@ -513,6 +488,7 @@ class Node(object):
             error: %(error)s,
             custom_physnets: %(custom_physnets)s,
             bond_mode: %(bond_mode)s,
+            dpdk_phy_name: %(dpdk_phy_name)s,
             ''' %
             {'dst_dir': self.dst_dir,
              'bash_script_path': self.bash_script_path,
@@ -599,7 +575,8 @@ class Node(object):
             'old_ivs_version': self.old_ivs_version,
             'error': self.error,
             'custom_physnets': self.custom_physnets,
-            'bond_mode': self.bond_mode})
+            'bond_mode': self.bond_mode,
+            'dpdk_phy_name': self.dpdk_phy_name})
 
     def __repr__(self):
         return self.__str__()

--- a/bosi/lib/node.py
+++ b/bosi/lib/node.py
@@ -157,30 +157,30 @@ class Node(object):
                             phy['bond_mode'].upper()]
 
         # setup DPDK custom_physnets
-        if self.role in const.DPDK_ROLES:
-            if (not 'physnets' in node_config
-                or len(node_config['physnets']) != 1):
-                self.skip = True
-                self.error = (r'''physnets not specified or more than one '''
-                              '''specified for DPDK node %(hostname)s'''
-                              % {'hostname': self.hostname})
-            if not self.skip:
-                for phy in node_config['physnets']:
-                    if ('phy_name' not in phy
-                        or 'uplink_interfaces' not in phy
-                        or len(phy['uplink_interfaces']) > 2):
-                        self.skip = True
-                        self.error = (r'''Either missing phy_name or '''
-                                      '''uplink_interfaces or more than 2 '''
-                                      '''uplink_interfaces found for SRIOV '''
-                                      '''node %(hostname)s''' %
-                                      {'hostname': self.hostname})
-                        break
-                    self.custom_physnets[phy['phy_name']] = \
-                        phy['uplink_interfaces']
-                    if 'bond_mode' in phy:
-                        self.bond_mode = const.BondMode[
-                            phy['bond_mode'].upper()]
+        # if self.role in const.DPDK_ROLES:
+        #     if (not 'physnets' in node_config
+        #         or len(node_config['physnets']) != 1):
+        #         self.skip = True
+        #         self.error = (r'''physnets not specified or more than one '''
+        #                       '''specified for DPDK node %(hostname)s'''
+        #                       % {'hostname': self.hostname})
+        #     if not self.skip:
+        #         for phy in node_config['physnets']:
+        #             if ('phy_name' not in phy
+        #                 or 'uplink_interfaces' not in phy
+        #                 or len(phy['uplink_interfaces']) > 2):
+        #                 self.skip = True
+        #                 self.error = (r'''Either missing phy_name or '''
+        #                               '''uplink_interfaces or more than 2 '''
+        #                               '''uplink_interfaces found for SRIOV '''
+        #                               '''node %(hostname)s''' %
+        #                               {'hostname': self.hostname})
+        #                 break
+        #             self.custom_physnets[phy['phy_name']] = \
+        #                 phy['uplink_interfaces']
+        #             if 'bond_mode' in phy:
+        #                 self.bond_mode = const.BondMode[
+        #                     phy['bond_mode'].upper()]
 
         # in case of config env (packstack), bond and br_bond
         # may be empty

--- a/etc/t5/bash_template/redhat_7_upgrade.sh
+++ b/etc/t5/bash_template/redhat_7_upgrade.sh
@@ -22,6 +22,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
+            yum remove -y python-networking-bigswitch
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             neutron-db-manage upgrade heads
@@ -34,6 +35,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-lldp
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable  neutron-bsn-lldp
@@ -45,6 +47,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-agent
             rpm -ivhU $pkg --force
             systemctl stop neutron-bsn-agent
             systemctl disable neutron-bsn-agent
@@ -55,6 +58,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-horizon-bsn"* ]]; then
+            yum remove -y python-horizon-bsn
             rpm -ivhU $pkg --force
             systemctl restart httpd
             break
@@ -69,6 +73,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
+            yum remove -y python-networking-bigswitch
             rpm -ivhU $pkg --force
             break
         fi
@@ -77,6 +82,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-agent
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl stop neutron-bsn-agent
@@ -88,6 +94,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-lldp
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable neutron-bsn-lldp

--- a/etc/t6/bash_template/redhat_7_upgrade.sh
+++ b/etc/t6/bash_template/redhat_7_upgrade.sh
@@ -22,6 +22,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
+            yum remove -y python-networking-bigswitch
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             neutron-db-manage upgrade heads
@@ -34,6 +35,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-lldp"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-lldp
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable  neutron-bsn-lldp
@@ -45,6 +47,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-agent
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl stop neutron-bsn-agent
@@ -56,6 +59,7 @@ controller() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-horizon-bsn"* ]]; then
+            yum remove -y python-horizon-bsn
             rpm -ivhU $pkg --force
             systemctl restart httpd
             break
@@ -70,6 +74,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"python-networking-bigswitch"* ]]; then
+            yum remove -y python-networking-bigswitch
             rpm -ivhU $pkg --force
             break
         fi
@@ -78,6 +83,7 @@ compute() {
     for pkg in $PKGS
     do
         if [[ $pkg == *"openstack-neutron-bigswitch-agent"* ]]; then
+            yum remove -y openstack-neutron-bigswitch-agent
             rpm -ivhU $pkg --force
             systemctl daemon-reload
             systemctl enable neutron-bsn-agent


### PR DESCRIPTION
Reviewer: @sarath-kumar 

(this is as per our discussion today, cleaning up previous stuff for ovs dpdk port - only for linux_bond for now)

 - this is partial change that only handles lldp change for
   linux_bond
 - neutron-bsn-lldp autodetects interfaces and starts sending
   lldp
 - default deployment will work so that API connection works
   with hostname as systemname for lldp
 - post initial deployment, we use this bosi to update
   neutron-bsn-lldp to change systemname to <hostname>-api
 - '-api' is suffix for linux bond interfaces which are used
   for openstack API communication