### PR TITLE
OSP-198: build changes to update customize scripts [cherry-pick]

### DIFF
--- a/bosi/rhosp_resources/master/ivs/README
+++ b/bosi/rhosp_resources/master/ivs/README
@@ -26,14 +26,11 @@ contains the Big Switch switch light virtual
 ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual debugging tools
 
-ifup-ivs
-is the script to bring up interfaces on switch light virtual
+customize.sh
+is the script to customize overcloud ISO image, adding BSN packages
 
-ifdown-ivs
-is the script to bring down interfaces on switch light virtual
-
-assign-ivs-ip
-is the script to assign ip address to interfaces on switch light virtual
+RUNME.sh
+is the script to finalize customize.sh and startup.sh with version numbers
 
 startup.sh
 is the script needs to be run on undercloud node first boot

--- a/bosi/rhosp_resources/master/ivs/RUNME.sh
+++ b/bosi/rhosp_resources/master/ivs/RUNME.sh
@@ -1,0 +1,62 @@
+#!/bin/bash -eux
+# Copyright 2018 Big Switch Networks, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+get_version () {
+    RPM=$1;
+    B=${RPM##*/};
+    B=${B%-*};
+    V=${B##*-};
+}
+
+IVS_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./ivs-debug*. 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    IVS_PKG="`ls ./ivs-debug*`"
+    get_version $IVS_PKG
+    IVS_VERSION=$V
+fi
+
+NETWORKING_BIGSWITCH_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-networking-bigswitch* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    BSNLIB_PKG="`ls ./python-networking-bigswitch*`"
+    get_version $BSNLIB_PKG
+    NETWORKING_BIGSWITCH_VERSION=$V
+fi
+
+HORIZON_BSN_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-horizon-bsn* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    HORIZON_PKG="`ls ./python-horizon-bsn*`"
+    get_version $HORIZON_PKG
+    HORIZON_BSN_VERSION=$V
+fi
+
+
+echo "ivs version is" $IVS_VERSION
+echo "networking-bigswitch version is" $NETWORKING_BIGSWITCH_VERSION
+echo "horizon-bsn version is" $HORIZON_BSN_VERSION
+
+# IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
+# that needs to be adhered.
+IVS_VERSION_REVISION="$IVS_VERSION""-1"
+
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./customize.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./startup.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./README

--- a/bosi/rhosp_resources/origin/stable/newton/ivs/README
+++ b/bosi/rhosp_resources/origin/stable/newton/ivs/README
@@ -26,14 +26,11 @@ contains the Big Switch switch light virtual
 ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual debugging tools
 
-ifup-ivs
-is the script to bring up interfaces on switch light virtual
+customize.sh
+is the script to customize overcloud ISO image, adding BSN packages
 
-ifdown-ivs
-is the script to bring down interfaces on switch light virtual
-
-assign-ivs-ip
-is the script to assign ip address to interfaces on switch light virtual
+RUNME.sh
+is the script to finalize customize.sh and startup.sh with version numbers
 
 startup.sh
 is the script needs to be run on undercloud node first boot

--- a/bosi/rhosp_resources/origin/stable/newton/ivs/RUNME.sh
+++ b/bosi/rhosp_resources/origin/stable/newton/ivs/RUNME.sh
@@ -1,0 +1,62 @@
+#!/bin/bash -eux
+# Copyright 2018 Big Switch Networks, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+get_version () {
+    RPM=$1;
+    B=${RPM##*/};
+    B=${B%-*};
+    V=${B##*-};
+}
+
+IVS_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./ivs-debug*. 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    IVS_PKG="`ls ./ivs-debug*`"
+    get_version $IVS_PKG
+    IVS_VERSION=$V
+fi
+
+NETWORKING_BIGSWITCH_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-networking-bigswitch* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    BSNLIB_PKG="`ls ./python-networking-bigswitch*`"
+    get_version $BSNLIB_PKG
+    NETWORKING_BIGSWITCH_VERSION=$V
+fi
+
+HORIZON_BSN_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-horizon-bsn* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    HORIZON_PKG="`ls ./python-horizon-bsn*`"
+    get_version $HORIZON_PKG
+    HORIZON_BSN_VERSION=$V
+fi
+
+
+echo "ivs version is" $IVS_VERSION
+echo "networking-bigswitch version is" $NETWORKING_BIGSWITCH_VERSION
+echo "horizon-bsn version is" $HORIZON_BSN_VERSION
+
+# IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
+# that needs to be adhered.
+IVS_VERSION_REVISION="$IVS_VERSION""-1"
+
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./customize.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./startup.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./README

--- a/bosi/rhosp_resources/origin/stable/ocata/ivs/README
+++ b/bosi/rhosp_resources/origin/stable/ocata/ivs/README
@@ -26,14 +26,11 @@ contains the Big Switch switch light virtual
 ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual debugging tools
 
-ifup-ivs
-is the script to bring up interfaces on switch light virtual
+customize.sh
+is the script to customize overcloud ISO image, adding BSN packages
 
-ifdown-ivs
-is the script to bring down interfaces on switch light virtual
-
-assign-ivs-ip
-is the script to assign ip address to interfaces on switch light virtual
+RUNME.sh
+is the script to finalize customize.sh and startup.sh with version numbers
 
 startup.sh
 is the script needs to be run on undercloud node first boot

--- a/bosi/rhosp_resources/origin/stable/ocata/ivs/RUNME.sh
+++ b/bosi/rhosp_resources/origin/stable/ocata/ivs/RUNME.sh
@@ -1,0 +1,62 @@
+#!/bin/bash -eux
+# Copyright 2018 Big Switch Networks, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+get_version () {
+    RPM=$1;
+    B=${RPM##*/};
+    B=${B%-*};
+    V=${B##*-};
+}
+
+IVS_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./ivs-debug*. 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    IVS_PKG="`ls ./ivs-debug*`"
+    get_version $IVS_PKG
+    IVS_VERSION=$V
+fi
+
+NETWORKING_BIGSWITCH_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-networking-bigswitch* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    BSNLIB_PKG="`ls ./python-networking-bigswitch*`"
+    get_version $BSNLIB_PKG
+    NETWORKING_BIGSWITCH_VERSION=$V
+fi
+
+HORIZON_BSN_VERSION='NOT-FOUND'
+COUNT="`ls -1 ./python-horizon-bsn* 2>/dev/null | wc -l`"
+if [ $COUNT != 0 ]
+then
+    HORIZON_PKG="`ls ./python-horizon-bsn*`"
+    get_version $HORIZON_PKG
+    HORIZON_BSN_VERSION=$V
+fi
+
+
+echo "ivs version is" $IVS_VERSION
+echo "networking-bigswitch version is" $NETWORKING_BIGSWITCH_VERSION
+echo "horizon-bsn version is" $HORIZON_BSN_VERSION
+
+# IVS_VERSION_REVISION includes ivs version with its revision number, default = -1. redhat naming convention
+# that needs to be adhered.
+IVS_VERSION_REVISION="$IVS_VERSION""-1"
+
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./customize.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./startup.sh
+sed -i -e "s/\${networking_bigswitch_version}/$NETWORKING_BIGSWITCH_VERSION/" -e "s/\${horizon_bsn_version}/$HORIZON_BSN_VERSION/" -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./README


### PR DESCRIPTION
Reviewer: trivial

 - instead of creating customize.sh and startup.sh with an array
   of OSP vs BCF versions, provide stubbed scripts
 - include a RUNME.sh script that updates the actual scripts based
   on packages in the directory