### PR TITLE
OSP-211: cleanup bigswitch-config-p.yaml [cherry-pick]

### DIFF
--- a/bosi/rhosp_resources/master/yamls/bigswitch-config-p.yaml
+++ b/bosi/rhosp_resources/master/yamls/bigswitch-config-p.yaml
@@ -5,14 +5,9 @@ resource_registry:
   OS::TripleO::ComputeExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/compute/neutron-ml2-bigswitch.yaml
 
 parameter_defaults:
-  ControllerExtraConfig:
-    neutron::agents::bigswitch::lldp_enabled: true
-    neutron::agents::dhcp::enable_force_metadata: true
-    neutron::agents::dhcp::enable_isolated_metadata: true
-    neutron::agents::dhcp::enable_metadata_network: false
-    neutron::server::l3_ha: false
   NeutronMechanismDrivers: openvswitch,bsn_ml2
-  KeystoneNotificationDriver: messaging
+  NeutronServicePlugins: router,qos,trunk,bsn_service_plugin
+  NeutronDebug: True
 
   NovaComputeExtraConfig:
     neutron::agents::bigswitch::lldp_enabled: true

--- a/bosi/rhosp_resources/origin/stable/newton/yamls/bigswitch-config-p.yaml
+++ b/bosi/rhosp_resources/origin/stable/newton/yamls/bigswitch-config-p.yaml
@@ -3,24 +3,17 @@ resource_registry:
   OS::TripleO::ComputeExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/compute/neutron-ml2-bigswitch.yaml
 
 parameter_defaults:
-  ControllerExtraConfig:
-    neutron::agents::bigswitch::lldp_enabled: true
-    neutron::agents::bigswitch::agent_enabled: false
-    neutron::agents::dhcp::enable_force_metadata: true
-    neutron::agents::dhcp::enable_isolated_metadata: true
-    neutron::agents::dhcp::enable_metadata_network: false
-    neutron::server::l3_ha: false
   NeutronMechanismDrivers: openvswitch,bsn_ml2
-  KeystoneNotificationDriver: messaging
+  NeutronServicePlugins: router,qos,trunk,bsn_service_plugin
+  NeutronDebug: True
 
   NovaComputeExtraConfig:
     neutron::agents::bigswitch::lldp_enabled: true
-    neutron::agents::bigswitch::agent_enabled: false
 
   NeutronBigswitchRestproxyServers: <Update-this-value>
   NeutronBigswitchRestproxyServerAuth: <Update-this-value>
   NeutronBigswitchRestproxyAutoSyncOnFailure: True
   NeutronBigswitchRestproxyConsistencyInterval: 10
-  NeutronBigswitchRestproxyNeutronId: <Update-this-value>
+  NeutronBigswitchRestproxyNeutronId: <Update-this-value> # <<< Name used to prefix the tenant/project name on BCF.
   NeutronBigswitchRestproxyServerSsl: True
   NeutronBigswitchRestproxySslCertDirectory: /var/lib/neutron

--- a/bosi/rhosp_resources/origin/stable/ocata/yamls/bigswitch-config-p.yaml
+++ b/bosi/rhosp_resources/origin/stable/ocata/yamls/bigswitch-config-p.yaml
@@ -5,14 +5,9 @@ resource_registry:
   OS::TripleO::ComputeExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/compute/neutron-ml2-bigswitch.yaml
 
 parameter_defaults:
-  ControllerExtraConfig:
-    neutron::agents::bigswitch::lldp_enabled: true
-    neutron::agents::dhcp::enable_force_metadata: true
-    neutron::agents::dhcp::enable_isolated_metadata: true
-    neutron::agents::dhcp::enable_metadata_network: false
-    neutron::server::l3_ha: false
   NeutronMechanismDrivers: openvswitch,bsn_ml2
-  KeystoneNotificationDriver: messaging
+  NeutronServicePlugins: router,qos,trunk,bsn_service_plugin
+  NeutronDebug: True
 
   NovaComputeExtraConfig:
     neutron::agents::bigswitch::lldp_enabled: true


### PR DESCRIPTION
Reviewer: trivial 

 - many properties were not required for p-only deployment