### PR TITLE
update customize scripts to include only neutron-bsn-lldp

### DIFF
--- a/bosi/rhosp_resources/master/ivs/README
+++ b/bosi/rhosp_resources/master/ivs/README
@@ -8,17 +8,8 @@ directory is verified to work with BCF 3.6 and RHOSP8.0.
 Please refer to BCF deployment guide for the steps to
 patch RHOSP overcloud images.
 
-python-networking-bigswitch-${networking_bigswitch_version}-1.el7.centos.noarch.rpm
-contains the Big Switch ml2 plugin and l3 service plugin
-
-openstack-neutron-bigswitch-lldp-${networking_bigswitch_version}-1.el7.centos.noarch.rpm
-contains the Big Switch lldp service
-
-openstack-neutron-bigswitch-agent-${networking_bigswitch_version}-1.el7.centos.noarch.rpm
-contains the Big Switch virtual switch agent
-
-python-horizon-bsn-${horizon_bsn_version}-1.el7.centos.noarch.rpm
-contains the Big Switch horizon plugin
+neutron-bsn-lldp-${lldp_version}-1.el7.centos.noarch.rpm
+contains the Big Switch LLDP service
 
 ivs-${ivs_version}.el7.centos.x86_64.rpm
 contains the Big Switch switch light virtual

--- a/bosi/rhosp_resources/master/ivs/customize.sh
+++ b/bosi/rhosp_resources/master/ivs/customize.sh
@@ -18,7 +18,7 @@ export LIBGUESTFS_BACKEND=direct
 
 image_dir="/home/stack/images"
 
-virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload neutron-bsn-lldp-0.0.1-1.el7.centos.noarch.rpm:/root/
+virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload neutron-bsn-lldp-${lldp_version}-1.el7.centos.noarch.rpm:/root/
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --firstboot startup.sh
 # enabled for P+V mode
 #virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-${ivs_version}.el7.centos.x86_64.rpm:/root/

--- a/bosi/rhosp_resources/master/ivs/startup.sh
+++ b/bosi/rhosp_resources/master/ivs/startup.sh
@@ -20,7 +20,7 @@ yum remove -y openstack-neutron-bigswitch-lldp
 yum remove -y python-networking-bigswitch
 
 yum remove -y neutron-bsn-lldp
-rpm -ivhU --force /root/neutron-bsn-lldp-0.0.1-1.el7.centos.noarch.rpm
+rpm -ivhU --force /root/neutron-bsn-lldp-${lldp_version}-1.el7.centos.noarch.rpm
 # enabled for P+V mode
 #rpm -ivhU --force /root/ivs-${ivs_version}.el7.centos.x86_64.rpm
 #rpm -ivhU --force /root/ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - this is because all other packages are now delivered as a
   container starting with RHOSP-13
 - i would remove the ivs portion of customize.sh as well - just waiting until we port that over to IVS jenkins job correctly