### PR TITLE
set version for new bcf-4.7.0 branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 0.0.217
+version = 4.7.0
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - because there are backward incompatible changes in BOSI starting
   with queens, we create a new branch for all BOSI changes
   henceforth for queens and onwards