### PR TITLE
bump version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 4.7.2
+version = 4.7.3
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: trivial

 - 4.7.2 doesn't seem to be uploaded to pypi