### PR TITLE
Rename network-environment-ivs.yaml to network-environment-bcf.yaml and change lacp=1 to lacp=fast

### DIFF
--- a/bosi/rhosp_resources/master/yamls/network-environment-bcf.yaml
+++ b/bosi/rhosp_resources/master/yamls/network-environment-bcf.yaml
@@ -48,6 +48,6 @@ parameter_defaults:
   # Set to empty string to enable multiple external networks or VLANs
   NeutronExternalNetworkBridge: "''"
   # Customize bonding options, e.g. "mode=4 lacp_rate=1 updelay=1000 miimon=100"
-  BondInterfaceOvsOptions: "mode=4 lacp_rate=1 updelay=1000 use_carrier=1"
+  BondInterfaceOvsOptions: "mode=4 lacp_rate=fast updelay=1000 use_carrier=1"
   NeutronNetworkType: "vlan"
   NeutronNetworkVLANRanges: "datacentre:2200:2250"


### PR DESCRIPTION
Reviewer: @wolverineav @sarath-kumar 

1. Rename network-environment-ivs.yaml to network-environment-bcf.yaml 
2. Change lacp=1 to lacp=fast

Based on Prashanth's feedback, the sample network-environment.yaml we provided can be used by both ovs and ivs, so renaming it to make it clear that it works with bcf.

lacp_rate change was another ask.

(Please help with the packaging if any additional procedures needs to be done, I am not yet familiar with the workflow of updating BOSI.)