### PR TITLE
[Cherry-Pick][4.7.0]Rename network-environment-ivs.yaml to network-environment-bcf.yaml nd change lacp=1 to lacp=fast

### DIFF
--- a/bosi/rhosp_resources/master/yamls/network-environment-bcf.yaml
+++ b/bosi/rhosp_resources/master/yamls/network-environment-bcf.yaml
@@ -48,6 +48,6 @@ parameter_defaults:
   # Set to empty string to enable multiple external networks or VLANs
   NeutronExternalNetworkBridge: "''"
   # Customize bonding options, e.g. "mode=4 lacp_rate=1 updelay=1000 miimon=100"
-  BondInterfaceOvsOptions: "mode=4 lacp_rate=1 updelay=1000 use_carrier=1"
+  BondInterfaceOvsOptions: "mode=4 lacp_rate=fast updelay=1000 use_carrier=1"
   NeutronNetworkType: "vlan"
   NeutronNetworkVLANRanges: "datacentre:2200:2250"


### PR DESCRIPTION
Reviewer: @wolverineav @sarath-kumar 

Cherry-Pick: https://github.com/bigswitch/bosi/pull/518

- Rename network-environment-ivs.yaml to network-environment-bcf.yaml
- Change lacp=1 to lacp=fast

Based on Prashanth's feedback, the sample network-environment.yaml we provided can be used by both ovs and ivs, so renaming it to make it clear that it works with bcf.

lacp_rate change was another ask.