### PR TITLE
use beta version of pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@
 pbr>=0.11,<2.0
 subprocess32>=3.2.6,<3.2.9
 futures>=3.0.2,<3.0.5
-pyyaml>=4.1,<4.3
+# pyyaml security vulnerability fix not available in GA as of now
+# hence using beta candidate
+pyyaml==4.2b4
 netaddr>=0.7.18,<0.8


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - the security fix is not GA-ed yet to pypi, use beta4