### PR TITLE
minor changes to add convenience [cherry-pick]

### DIFF
--- a/bosi/rhosp_resources/master/ivs/customize.sh
+++ b/bosi/rhosp_resources/master/ivs/customize.sh
@@ -21,9 +21,9 @@ image_dir="/home/stack/images"
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload neutron-bsn-lldp-${lldp_version}-1.el7.centos.noarch.rpm:/root/
 # enabled for P+V mode
 #ivs_version="TODO set_IVS_version_here_if_deploying_PV_mode"
-#virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-${ivs_version}.el7.centos.x86_64.rpm:/root/
-#virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm:/root/
-#sed -i -e "s/\${ivs_version}/$IVS_VERSION_REVISION/" ./startup.sh
+#virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-${ivs_version}-1.el7.centos.x86_64.rpm:/root/
+#virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload ivs-debuginfo-${ivs_version}-1.el7.centos.x86_64.rpm:/root/
+#sed -i -e "s/\${ivs_version}/$ivs_version/" ./startup.sh
 
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --upload impl_ifcfg.py:/root/
 virt-customize -a ${image_dir}/overcloud-full.qcow2 --firstboot startup.sh

--- a/bosi/rhosp_resources/master/ivs/startup.sh
+++ b/bosi/rhosp_resources/master/ivs/startup.sh
@@ -22,8 +22,8 @@ yum remove -y python-networking-bigswitch
 yum remove -y neutron-bsn-lldp
 rpm -ivhU --force /root/neutron-bsn-lldp-${lldp_version}-1.el7.centos.noarch.rpm
 # enabled for P+V mode
-#rpm -ivhU --force /root/ivs-${ivs_version}.el7.centos.x86_64.rpm
-#rpm -ivhU --force /root/ivs-debuginfo-${ivs_version}.el7.centos.x86_64.rpm
+#rpm -ivhU --force /root/ivs-${ivs_version}-1.el7.centos.x86_64.rpm
+#rpm -ivhU --force /root/ivs-debuginfo-${ivs_version}-1.el7.centos.x86_64.rpm
 systemctl enable neutron-bsn-lldp.service
 systemctl restart neutron-bsn-lldp.service
 # workaround for ivs restart not happening

--- a/bosi/rhosp_resources/master/yamls/overcloud_images_bigswitch.yaml
+++ b/bosi/rhosp_resources/master/yamls/overcloud_images_bigswitch.yaml
@@ -7,6 +7,6 @@ parameter_defaults:
   DockerHorizonImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-horizon-bigswitch:13.0-4
   DockerHorizonConfigImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-horizon-bigswitch:13.0-4
 # uncomment for PV mode  
-#  DockerNeutronBigswitchAgentImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-neutron-server-bigswitch:13.0-1
+#  DockerNeutronBigswitchAgentImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-neutron-server-bigswitch:13.0-3
 #  DockerNovaComputeImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-nova-compute-bigswitch:13.0-2
 #  DockerNovaLibvirtConfigImage: <REGISTRY_IP>:8787/bigswitch/rhosp13-openstack-nova-compute-bigswitch:13.0-2


### PR DESCRIPTION
Reviewer: trivial

 - do not require user to enter '-1' at the end of version string
   for IVS
 - update container tag in commented part of overcloud images