### PR TITLE
add helper script to clear bcf ssl certs when forced to do so

### DIFF
--- a/bosi/rhosp_resources/master/ivs/clear_bcf_ssl_certs.sh
+++ b/bosi/rhosp_resources/master/ivs/clear_bcf_ssl_certs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+# Make sure only root can run this script
+if [ "$(id -u)" != "0" ]; then
+   echo -e "Please run as root"
+   exit 1
+fi
+
+CERTS_DIR=`docker inspect neutron_api | jq ".[0].GraphDriver.Data.UpperDir" | tr -d '"'`
+
+echo "deleting certs from "$CERTS_DIR
+rm -rf $CERTS_DIR/var/lib/neutron/host_certs/*.pem
+rm -rf $CERTS_DIR/var/lib/neutron/ca_certs/*.pem
+rm -rf $CERTS_DIR/var/lib/neutron/combined/*.pem
+
+docker restart neutron_api

--- a/bosi/rhosp_resources/origin/stable/pike/ivs/clear_bcf_ssl_certs.sh
+++ b/bosi/rhosp_resources/origin/stable/pike/ivs/clear_bcf_ssl_certs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+# Make sure only root can run this script
+if [ "$(id -u)" != "0" ]; then
+   echo -e "Please run as root"
+   exit 1
+fi
+
+CERTS_DIR=`docker inspect neutron_api | jq ".[0].GraphDriver.Data.UpperDir" | tr -d '"'`
+
+echo "deleting certs from "$CERTS_DIR
+rm -rf $CERTS_DIR/var/lib/neutron/host_certs/*.pem
+rm -rf $CERTS_DIR/var/lib/neutron/ca_certs/*.pem
+rm -rf $CERTS_DIR/var/lib/neutron/combined/*.pem
+
+docker restart neutron_api


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - this is currently being used by QA
 - backup for the case when clearing certs is necessary