### PR TITLE
update pyyaml to match newton env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 pbr>=0.11,<2.0
 subprocess32>=3.2.6,<3.2.9
 futures>=3.0.2,<3.0.5
-# pyyaml security vulnerability fix not available in GA as of now
-# hence using beta candidate
-pyyaml==4.2b4
+# update pyyaml requirement to match newton env
+pyyaml>=3.1.0,<4.3
 netaddr>=0.7.18,<0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bosi
-version = 4.0.34
+version = 4.0.35
 summary = Big Switch Networks OpenStack Installer
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - the beta version installation fails because newton env includes
   pyyaml 3.10 as a dependency for other packages such as:
   oslo.vmware, os-net-config, os-apply-config, diskimage-builder, etc
 - match that to avoid conflicts